### PR TITLE
Add new decorators for client/server close.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-testing</artifactId>
+      <version>${grpc.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
@@ -181,6 +188,20 @@
           <repo>maven</repo>
           <packageName>opentracing-grpc</packageName>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/opentracing/contrib/grpc/ClientCloseDecorator.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ClientCloseDecorator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.grpc;
+
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.opentracing.Span;
+
+public interface ClientCloseDecorator {
+  /**
+   * The method of the implementation is executed inside
+   * {@link ForwardingClientCallListener#onClose(Status, Metadata)}
+   * @param span The span created by {@link ClientTracingInterceptor}
+   * @param status The status passed to {@link ForwardingClientCallListener#onClose(Status, Metadata)}.
+   * @param trailers The trailing headers passed to {@link ForwardingClientCallListener#onClose(Status, Metadata)}
+   */
+  void close(Span span, Status status, Metadata trailers);
+}

--- a/src/main/java/io/opentracing/contrib/grpc/ServerCloseDecorator.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ServerCloseDecorator.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.grpc;
+
+import io.grpc.ForwardingServerCall;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+import io.opentracing.Span;
+
+/**
+ * An interface for adding custom span tags to the spans created by
+ * {@link ServerTracingInterceptor} when the gRPC call is closed.
+ */
+public interface ServerCloseDecorator {
+  /**
+   * The method of the implementation is executed inside
+   * {@link ForwardingServerCall#close(Status, Metadata)}
+   * @param span The span created by {@link ServerTracingInterceptor}
+   * @param status The status passed to {@link ServerCall#close(Status, Metadata)}.
+   * @param trailers The trailing headers passed to {@link ServerCall#close(Status, Metadata)}
+   */
+  void close(Span span, Status status, Metadata trailers);
+}

--- a/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
@@ -14,29 +14,19 @@
 package io.opentracing.contrib.grpc;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.opentracing.contrib.grpc.gen.GreeterGrpc;
 import io.opentracing.contrib.grpc.gen.HelloRequest;
 
 public class TracedClient {
 
-  private final ManagedChannel channel;
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
-  public TracedClient(String host, int port, ClientTracingInterceptor tracingInterceptor) {
-    channel = ManagedChannelBuilder.forAddress(host, port)
-        .usePlaintext()
-        .build();
-
+  public TracedClient(ManagedChannel channel, ClientTracingInterceptor tracingInterceptor) {
     if (tracingInterceptor == null) {
       blockingStub = GreeterGrpc.newBlockingStub(channel);
     } else {
       blockingStub = GreeterGrpc.newBlockingStub(tracingInterceptor.intercept(channel));
     }
-  }
-
-  void shutdown() throws InterruptedException {
-    channel.shutdown();
   }
 
   boolean greet(String name) {
@@ -45,14 +35,7 @@ public class TracedClient {
       blockingStub.sayHello(request);
     } catch (Exception e) {
       return false;
-    } finally {
-      try {
-        this.shutdown();
-      } catch (Exception e) {
-        return false;
-      }
     }
     return true;
-
   }
 }


### PR DESCRIPTION
Currently, it is not possible to set tags on the span based on the
result of a gRPC call (for example, to include the gRPC status code).
Add a new decorator interface to both client and server builders which
allows setting custom tags when the gRPC call is closed.

Fixes #20.