### PR TITLE
Add common tags to server and client spans.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,8 +284,7 @@ ClientTracingInterceptor clientInterceptor = new ClientTracingInterceptor
     .withClientCloseDecorator(new ClientCloseDecorator() {
         @Override
         public void close(Span span, Status status, Metadata trailers) {
-            span.setTag("grpc.status", status.getCode().name());
-            Tags.ERROR.set(span, !status.isOk());
+            span.setTag("grpc.statusCode", status.getCode().value());
         }
     })
     ...
@@ -304,8 +303,7 @@ ServerTracingInterceptor serverInterceptor = new ServerTracingInterceptor
     .withServerCloseDecorator(new ServerCloseDecorator() {
         @Override
         public void close(Span span, Status status, Metadata trailers) {
-            span.setTag("grpc.status", status.getCode().name());
-            Tags.ERROR.set(span, !status.isOk());
+            span.setTag("grpc.statusCode", status.getCode().value());
         }
     })
     ...

--- a/src/main/java/io/opentracing/contrib/grpc/GrpcTags.java
+++ b/src/main/java/io/opentracing/contrib/grpc/GrpcTags.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.grpc;
+
+import io.grpc.Status;
+import io.opentracing.Span;
+import io.opentracing.tag.StringTag;
+import io.opentracing.tag.Tags;
+
+/**
+ * Package private utility methods for common gRPC tags.
+ */
+final class GrpcTags {
+    private GrpcTags() {}
+
+    /** gRPC status code tag */
+    static StringTag GRPC_STATUS = new StringTag("grpc.status");
+
+    /** Value for {@link Tags#COMPONENT} for gRPC */
+    static String COMPONENT_VALUE = "grpc-java";
+
+    /**
+     * Sets {@code grpc.status} and {@code error} tags on span.
+     * @param span Span
+     * @param status gRPC call status
+     */
+    static void setStatusTags(Span span, Status status) {
+        GRPC_STATUS.set(span, status.getCode().name());
+        if (!status.isOk()) {
+            Tags.ERROR.set(span, true);
+        }
+    }
+}

--- a/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.grpc;
+
+import io.grpc.Status;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import org.assertj.core.data.MapEntry;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GrpcTagsTest {
+    @Test
+    public void testStatusOk() {
+        final Status status = Status.OK;
+        MockSpan span = new MockTracer().buildSpan("").start();
+        GrpcTags.setStatusTags(span, status);
+        assertThat(span.tags())
+            .containsExactly(MapEntry.entry(GrpcTags.GRPC_STATUS.getKey(), status.getCode().name()));
+    }
+
+    @Test
+    public void testStatusError() {
+        final Status status = Status.INTERNAL;
+        MockSpan span = new MockTracer().buildSpan("").start();
+        GrpcTags.setStatusTags(span, status);
+        assertThat(span.tags())
+                .containsOnly(
+                    MapEntry.entry(GrpcTags.GRPC_STATUS.getKey(), status.getCode().name()),
+                    MapEntry.entry(Tags.ERROR.getKey(), Boolean.TRUE)
+                );
+    }
+}


### PR DESCRIPTION
Add `component=grpc-java`, `grpc.status=<code>`, and `error=true` (for
non-OK status codes) to server and client spans. Add `span.kind=server`
to server spans and `span.kind=client` to client spans. Update tests to
reflect new tags and migrate some existing tests to use AssertJ.

Fixes #22.