### PR TITLE
Support optional peer.address tag on server span.

### DIFF
--- a/src/main/java/io/opentracing/contrib/grpc/ServerTracingInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ServerTracingInterceptor.java
@@ -145,6 +145,9 @@ public class ServerTracingInterceptor implements ServerInterceptor {
         case HEADERS:
           span.setTag("grpc.headers", headers.toString());
           break;
+        case PEER_ADDRESS:
+          GrpcTags.setPeerAddressTag(span, call.getAttributes());
+          break;
       }
     }
 
@@ -334,7 +337,8 @@ public class ServerTracingInterceptor implements ServerInterceptor {
     HEADERS,
     METHOD_TYPE,
     METHOD_NAME,
-    CALL_ATTRIBUTES
+    CALL_ATTRIBUTES,
+    PEER_ADDRESS
   }
 
 }


### PR DESCRIPTION
Update the server interceptor to set the `peer.address` to the host and
port (for socket addresses) or the in-process server name (for
in-process addresses).

Fixes #23.