### PR TITLE
Don't set error tag in interceptor.

### DIFF
--- a/src/main/java/io/opentracing/contrib/grpc/GrpcTags.java
+++ b/src/main/java/io/opentracing/contrib/grpc/GrpcTags.java
@@ -53,9 +53,6 @@ final class GrpcTags {
    */
   static void setStatusTags(Span span, Status status) {
     GRPC_STATUS.set(span, status.getCode().name());
-    if (!status.isOk()) {
-      Tags.ERROR.set(span, true);
-    }
   }
 
   /**

--- a/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
@@ -21,7 +21,6 @@ import io.grpc.Status;
 import io.grpc.inprocess.InProcessSocketAddress;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
-import io.opentracing.tag.Tags;
 import java.net.InetSocketAddress;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -45,8 +44,7 @@ public class GrpcTagsTest {
     GrpcTags.setStatusTags(span, status);
     assertThat(span.tags())
         .containsOnly(
-            MapEntry.entry(GrpcTags.GRPC_STATUS.getKey(), status.getCode().name()),
-            MapEntry.entry(Tags.ERROR.getKey(), Boolean.TRUE)
+            MapEntry.entry(GrpcTags.GRPC_STATUS.getKey(), status.getCode().name())
         );
   }
 


### PR DESCRIPTION
Consumers of the gRPC instrumentation may want to have more control over
use of the error tag. For example, a server span which returns NOT_FOUND
may not necessarily be an error server side (it could be expected).
Removing the setting of this tag will give more control to consumers to
determine which gRPC calls are errors or not.