### PR TITLE
Fixing client and server tracing interceptors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   </issueManagement>
 
   <properties>
-    <java.version>8</java.version>
+    <java.version>1.7</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   </issueManagement>
 
   <properties>
-    <java.version>1.7</java.version>
+    <java.version>8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 

--- a/src/main/java/io/opentracing/contrib/grpc/ClientTracingInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ClientTracingInterceptor.java
@@ -14,6 +14,7 @@
 package io.opentracing.contrib.grpc;
 
 import com.google.common.collect.ImmutableMap;
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -24,6 +25,7 @@ import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
+import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -126,148 +128,187 @@ public class ClientTracingInterceptor implements ClientInterceptor {
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
       MethodDescriptor<ReqT, RespT> method,
       CallOptions callOptions,
-      Channel next
-  ) {
+      Channel next) {
+
     final String operationName = operationNameConstructor.constructOperationName(method);
 
     SpanContext activeSpanContext = getActiveSpanContext();
     final Span span = createSpanFromParent(activeSpanContext, operationName);
 
-    if (clientSpanDecorator != null) {
-      clientSpanDecorator.interceptCall(span, method, callOptions);
-    }
+    try (Scope ignored = tracer.scopeManager().activate(span)) {
 
-    for (ClientRequestAttribute attr : this.tracedAttributes) {
-      switch (attr) {
-        case ALL_CALL_OPTIONS:
-          span.setTag(attr.key, callOptions.toString());
-          break;
-        case AUTHORITY:
-          span.setTag(attr.key, String.valueOf(callOptions.getAuthority()));
-          break;
-        case COMPRESSOR:
-          span.setTag(attr.key, String.valueOf(callOptions.getCompressor()));
-          break;
-        case DEADLINE:
-          if (callOptions.getDeadline() == null) {
-            span.setTag(attr.key, "null");
-          } else {
-            span.setTag(attr.key,
-                callOptions.getDeadline().timeRemaining(TimeUnit.MILLISECONDS));
-          }
-          break;
-        case METHOD_NAME:
-          span.setTag(attr.key, method.getFullMethodName());
-          break;
-        case METHOD_TYPE:
-          span.setTag(attr.key, String.valueOf(method.getType()));
-          break;
-        case HEADERS:
-          break;
+      if (clientSpanDecorator != null) {
+        clientSpanDecorator.interceptCall(span, method, callOptions);
       }
-    }
 
-    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
-        next.newCall(method, callOptions)) {
-
-      @Override
-      public void start(Listener<RespT> responseListener, final Metadata headers) {
-        if (verbose) {
-          span.log("Started call");
-        }
-        if (tracedAttributes.contains(ClientRequestAttribute.HEADERS)) {
-          span.setTag(ClientRequestAttribute.HEADERS.key, headers.toString());
-        }
-
-        tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, new TextMap() {
-          @Override
-          public void put(String key, String value) {
-            Metadata.Key<String> headerKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
-            headers.put(headerKey, value);
-          }
-
-          @Override
-          public Iterator<Entry<String, String>> iterator() {
-            throw new UnsupportedOperationException(
-                "TextMapInjectAdapter should only be used with Tracer.inject()");
-          }
-        });
-
-        Listener<RespT> tracingResponseListener = new ForwardingClientCallListener
-            .SimpleForwardingClientCallListener<RespT>(responseListener) {
-
-          @Override
-          public void onHeaders(Metadata headers) {
-            if (verbose) {
-              span.log(ImmutableMap.of("Response headers received", headers.toString()));
+      for (ClientRequestAttribute attr : this.tracedAttributes) {
+        switch (attr) {
+          case ALL_CALL_OPTIONS:
+            span.setTag(attr.key, callOptions.toString());
+            break;
+          case AUTHORITY:
+            span.setTag(attr.key, String.valueOf(callOptions.getAuthority()));
+            break;
+          case COMPRESSOR:
+            span.setTag(attr.key, String.valueOf(callOptions.getCompressor()));
+            break;
+          case DEADLINE:
+            if (callOptions.getDeadline() == null) {
+              span.setTag(attr.key, "null");
+            } else {
+              span.setTag(attr.key,
+                  callOptions.getDeadline().timeRemaining(TimeUnit.MILLISECONDS));
             }
-            delegate().onHeaders(headers);
+            break;
+          case METHOD_NAME:
+            span.setTag(attr.key, method.getFullMethodName());
+            break;
+          case METHOD_TYPE:
+            span.setTag(attr.key, String.valueOf(method.getType()));
+            break;
+          case HEADERS:
+            break;
+        }
+      }
+
+      return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+          next.newCall(method, callOptions)) {
+
+        @Override
+        public void start(Listener<RespT> responseListener, final Metadata headers) {
+          if (verbose) {
+            span.log("Started call");
+          }
+          if (tracedAttributes.contains(ClientRequestAttribute.HEADERS)) {
+            span.setTag(ClientRequestAttribute.HEADERS.key, headers.toString());
           }
 
-          @Override
-          public void onMessage(RespT message) {
-            if (streaming || verbose) {
-              span.log("Response received");
+          tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, new TextMap() {
+            @Override
+            public void put(String key, String value) {
+              Metadata.Key<String> headerKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+              headers.put(headerKey, value);
             }
-            delegate().onMessage(message);
-          }
 
-          @Override
-          public void onClose(Status status, Metadata trailers) {
-            if (verbose) {
-              if (status.getCode().value() == 0) {
-                span.log("Call closed");
-              } else {
-                if (status.getDescription() == null) {
+            @Override
+            public Iterator<Entry<String, String>> iterator() {
+              throw new UnsupportedOperationException(
+                  "TextMapInjectAdapter should only be used with Tracer.inject()");
+            }
+          });
+
+          Listener<RespT> tracingResponseListener = new ForwardingClientCallListener
+              .SimpleForwardingClientCallListener<RespT>(responseListener) {
+
+            @Override
+            public void onHeaders(Metadata headers) {
+              if (verbose) {
+                span.log(ImmutableMap.of("Response headers received", headers.toString()));
+              }
+              delegate().onHeaders(headers);
+            }
+
+            @Override
+            public void onMessage(RespT message) {
+              if (streaming || verbose) {
+                span.log("Response received");
+              }
+              delegate().onMessage(message);
+            }
+
+            @Override
+            public void onClose(Status status, Metadata trailers) {
+              if (verbose) {
+                if (status.getCode().value() == 0) {
+                  span.log("Call closed");
+                } else if (status.getDescription() == null) {
                   span.log(ImmutableMap.of("Call failed", "null"));
                 } else {
                   span.log(ImmutableMap.of("Call failed", status.getDescription()));
                 }
               }
+              GrpcTags.setStatusTags(span, status);
+              if (clientCloseDecorator != null) {
+                clientCloseDecorator.close(span, status, trailers);
+              }
+              delegate().onClose(status, trailers);
+              span.finish();
             }
-            GrpcTags.setStatusTags(span, status);
-            if (clientCloseDecorator != null) {
-              clientCloseDecorator.close(span, status, trailers);
-            }
-            span.finish();
-            delegate().onClose(status, trailers);
+          };
+
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            delegate().start(tracingResponseListener, headers);
           }
-        };
-        delegate().start(tracingResponseListener, headers);
-      }
+        }
 
-      @Override
-      public void cancel(@Nullable String message, @Nullable Throwable cause) {
-        String errorMessage;
-        if (message == null) {
-          errorMessage = "Error";
-        } else {
-          errorMessage = message;
+        @Override
+        public void request(int numMessages) {
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            delegate().request(numMessages);
+          }
         }
-        if (cause == null) {
-          span.log(errorMessage);
-        } else {
-          span.log(ImmutableMap.of(errorMessage, cause.getMessage()));
-        }
-        delegate().cancel(message, cause);
-      }
 
-      @Override
-      public void halfClose() {
-        if (streaming) {
-          span.log("Finished sending messages");
-        }
-        delegate().halfClose();
-      }
 
-      @Override
-      public void sendMessage(ReqT message) {
-        if (streaming || verbose) {
-          span.log("Message sent");
+        @Override
+        public void cancel(@Nullable String message, @Nullable Throwable cause) {
+          String errorMessage;
+          if (message == null) {
+            errorMessage = "Error";
+          } else {
+            errorMessage = message;
+          }
+          if (cause == null) {
+            span.log(errorMessage);
+          } else {
+            span.log(ImmutableMap.of(errorMessage, cause.getMessage()));
+          }
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            delegate().cancel(message, cause);
+          }
         }
-        delegate().sendMessage(message);
-      }
-    };
+
+        @Override
+        public void halfClose() {
+          if (streaming) {
+            span.log("Finished sending messages");
+          }
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            delegate().halfClose();
+          }
+        }
+
+        @Override
+        public void sendMessage(ReqT message) {
+          if (streaming || verbose) {
+            span.log("Message sent");
+          }
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            delegate().sendMessage(message);
+          }
+        }
+
+        @Override
+        public boolean isReady() {
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            return delegate().isReady();
+          }
+        }
+
+        @Override
+        public void setMessageCompression(boolean enabled) {
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            delegate().setMessageCompression(enabled);
+          }
+        }
+
+        @Override
+        public Attributes getAttributes() {
+          try (Scope ignored = tracer.scopeManager().activate(span)) {
+            return delegate().getAttributes();
+          }
+        }
+      };
+    }
   }
 
   private Span createSpanFromParent(SpanContext parentSpanContext, String operationName) {
@@ -277,7 +318,8 @@ public class ClientTracingInterceptor implements ClientInterceptor {
     } else {
       spanBuilder = tracer.buildSpan(operationName).asChildOf(parentSpanContext);
     }
-    return spanBuilder.withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+    return spanBuilder
+        .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
         .withTag(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .start();
   }

--- a/src/main/java/io/opentracing/contrib/grpc/GrpcFields.java
+++ b/src/main/java/io/opentracing/contrib/grpc/GrpcFields.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.grpc;
+
+final class GrpcFields {
+
+    static final String ERROR = "error";
+    static final String HEADERS = "headers";
+
+    static final String CLIENT_CALL_START = "client-call-start";
+    static final String CLIENT_CALL_CANCEL = "client-call-cancel";
+    static final String CLIENT_CALL_HALF_CLOSE = "client-call-half-close";
+    static final String CLIENT_CALL_SEND_MESSAGE = "client-call-send-message";
+
+    static final String CLIENT_CALL_LISTENER_ON_HEADERS = "client-call-listener-on-headers";
+    static final String CLIENT_CALL_LISTENER_ON_MESSAGE = "client-call-listener-on-message";
+    static final String CLIENT_CALL_LISTENER_ON_CLOSE = "client-call-listener-on-close";
+
+    static final String SERVER_CALL_SEND_HEADERS = "server-call-send-headers";
+    static final String SERVER_CALL_SEND_MESSAGE = "server-call-send-message";
+    static final String SERVER_CALL_CLOSE = "server-call-close";
+
+    static final String SERVER_CALL_LISTENER_ON_MESSAGE = "server-call-listener-on-message";
+    static final String SERVER_CALL_LISTENER_ON_HALF_CLOSE = "server-call-listener-on-half-close";
+    static final String SERVER_CALL_LISTENER_ON_CANCEL = "server-call-listener-on-cancel";
+    static final String SERVER_CALL_LISTENER_ON_COMPLETE = "server-call-listener-on-complete";
+}

--- a/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
@@ -32,7 +32,7 @@ public class GrpcTagsTest {
   public void testStatusOk() {
     final Status status = Status.OK;
     MockSpan span = new MockTracer().buildSpan("").start();
-    GrpcTags.setStatusTags(span, status);
+    GrpcTags.GRPC_STATUS.set(span, status);
     assertThat(span.tags())
         .containsExactly(MapEntry.entry(GrpcTags.GRPC_STATUS.getKey(), status.getCode().name()));
   }
@@ -41,7 +41,7 @@ public class GrpcTagsTest {
   public void testStatusError() {
     final Status status = Status.INTERNAL;
     MockSpan span = new MockTracer().buildSpan("").start();
-    GrpcTags.setStatusTags(span, status);
+    GrpcTags.GRPC_STATUS.set(span, status);
     assertThat(span.tags())
         .containsOnly(
             MapEntry.entry(GrpcTags.GRPC_STATUS.getKey(), status.getCode().name())
@@ -56,7 +56,7 @@ public class GrpcTagsTest {
         .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, address)
         .build();
     MockSpan span = new MockTracer().buildSpan("").start();
-    GrpcTags.setPeerAddressTag(span, attributes);
+    GrpcTags.PEER_ADDRESS.set(span, attributes);
     assertThat(span.tags())
         .containsOnly(MapEntry.entry(GrpcTags.PEER_ADDRESS.getKey(),
             address.getHostString() + ':' + address.getPort()));
@@ -69,7 +69,7 @@ public class GrpcTagsTest {
         .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, address)
         .build();
     MockSpan span = new MockTracer().buildSpan("").start();
-    GrpcTags.setPeerAddressTag(span, attributes);
+    GrpcTags.PEER_ADDRESS.set(span, attributes);
     assertThat(span.tags())
         .containsOnly(MapEntry.entry(GrpcTags.PEER_ADDRESS.getKey(), address.getName()));
   }

--- a/src/test/java/io/opentracing/contrib/grpc/SecondClientInterceptor.java
+++ b/src/test/java/io/opentracing/contrib/grpc/SecondClientInterceptor.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.grpc;
+
+import static org.junit.Assert.assertNotNull;
+
+import io.grpc.Attributes;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.ForwardingClientCallListener;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.opentracing.mock.MockTracer;
+import javax.annotation.Nullable;
+
+public class SecondClientInterceptor implements ClientInterceptor {
+
+    private final MockTracer tracer;
+
+    public SecondClientInterceptor(MockTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+        MethodDescriptor<ReqT, RespT> method,
+        CallOptions callOptions,
+        Channel next) {
+
+        assertNotNull(tracer.activeSpan());
+
+        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            next.newCall(method, callOptions)) {
+
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+                assertNotNull(tracer.activeSpan());
+                delegate().start(new ForwardingClientCallListener
+                    .SimpleForwardingClientCallListener<RespT>(responseListener) {}, headers);
+            }
+
+            @Override
+            public void request(int numMessages) {
+                assertNotNull(tracer.activeSpan());
+                delegate().request(numMessages);
+            }
+
+            @Override
+            public void cancel(@Nullable String message, @Nullable Throwable cause) {
+                assertNotNull(tracer.activeSpan());
+                delegate().cancel(message, cause);
+            }
+
+            @Override
+            public void halfClose() {
+                assertNotNull(tracer.activeSpan());
+                delegate().halfClose();
+            }
+
+            @Override
+            public void sendMessage(ReqT message) {
+                assertNotNull(tracer.activeSpan());
+                delegate().sendMessage(message);
+            }
+
+            @Override
+            public boolean isReady() {
+                assertNotNull(tracer.activeSpan());
+                return delegate().isReady();
+            }
+
+            @Override
+            public void setMessageCompression(boolean enabled) {
+                assertNotNull(tracer.activeSpan());
+                delegate().setMessageCompression(enabled);
+            }
+
+            @Override
+            public Attributes getAttributes() {
+                assertNotNull(tracer.activeSpan());
+                return delegate().getAttributes();
+            }
+        };
+    }
+}

--- a/src/test/java/io/opentracing/contrib/grpc/SecondServerInterceptor.java
+++ b/src/test/java/io/opentracing/contrib/grpc/SecondServerInterceptor.java
@@ -24,7 +24,6 @@ import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
-import io.opentracing.Span;
 import io.opentracing.mock.MockTracer;
 
 public class SecondServerInterceptor implements ServerInterceptor {

--- a/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
@@ -13,6 +13,8 @@
  */
 package io.opentracing.contrib.grpc;
 
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 import io.opentracing.contrib.grpc.gen.GreeterGrpc;
 import io.opentracing.contrib.grpc.gen.HelloRequest;
@@ -21,12 +23,12 @@ public class TracedClient {
 
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
-  public TracedClient(ManagedChannel channel, ClientTracingInterceptor tracingInterceptor) {
-    if (tracingInterceptor == null) {
-      blockingStub = GreeterGrpc.newBlockingStub(channel);
-    } else {
-      blockingStub = GreeterGrpc.newBlockingStub(tracingInterceptor.intercept(channel));
-    }
+  public TracedClient(ManagedChannel channel) {
+    blockingStub = GreeterGrpc.newBlockingStub(channel);
+  }
+
+  public TracedClient(ManagedChannel channel, ClientInterceptor... interceptors) {
+    blockingStub = GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel, interceptors));
   }
 
   boolean greet(String name) {

--- a/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
@@ -13,26 +13,36 @@
  */
 package io.opentracing.contrib.grpc;
 
+import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
 import io.opentracing.contrib.grpc.gen.GreeterGrpc;
 import io.opentracing.contrib.grpc.gen.HelloRequest;
+import java.util.concurrent.TimeUnit;
 
 public class TracedClient {
 
   private final GreeterGrpc.GreeterBlockingStub blockingStub;
 
   public TracedClient(ManagedChannel channel) {
-    blockingStub = GreeterGrpc.newBlockingStub(channel);
+    blockingStub = createStub(channel);
   }
 
   public TracedClient(ManagedChannel channel, ClientInterceptor... interceptors) {
-    blockingStub = GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel, interceptors));
+    blockingStub = createStub(ClientInterceptors.intercept(channel, interceptors));
+  }
+
+  private GreeterGrpc.GreeterBlockingStub createStub(Channel channel) {
+    return GreeterGrpc.newBlockingStub(channel)
+        .withDeadlineAfter(500, TimeUnit.MILLISECONDS)
+        .withCompression("gzip");
   }
 
   boolean greet(String name) {
-    HelloRequest request = HelloRequest.newBuilder().setName(name).build();
+    HelloRequest request = HelloRequest.newBuilder()
+        .setName(name)
+        .build();
     try {
       blockingStub.sayHello(request);
     } catch (Exception e) {

--- a/src/test/java/io/opentracing/contrib/grpc/TracedService.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracedService.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing.contrib.grpc;
 
+import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.stub.StreamObserver;
 import io.grpc.util.MutableHandlerRegistry;
@@ -27,16 +28,11 @@ public class TracedService {
     registry.addService(new GreeterImpl());
   }
 
-  void addGreeterServiceWithInterceptor(ServerTracingInterceptor tracingInterceptor,
-      MutableHandlerRegistry registry) {
-    registry.addService(ServerInterceptors.intercept(new GreeterImpl(), tracingInterceptor));
-  }
+  void addGreeterServiceWithInterceptors(
+      MutableHandlerRegistry registry,
+      ServerInterceptor... interceptors) {
 
-  void addGreeterServiceWithTwoInterceptors(ServerTracingInterceptor tracingInterceptor,
-      SecondServerInterceptor secondServerInterceptor,
-      MutableHandlerRegistry registry) {
-    registry.addService(ServerInterceptors
-        .intercept(new GreeterImpl(), secondServerInterceptor, tracingInterceptor));
+    registry.addService(ServerInterceptors.intercept(new GreeterImpl(), interceptors));
   }
 
   private class GreeterImpl extends GreeterGrpc.GreeterImplBase {
@@ -51,7 +47,6 @@ public class TracedService {
       HelloReply reply = HelloReply.newBuilder().setMessage("Hello").build();
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
-
     }
   }
 }

--- a/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
@@ -39,11 +39,12 @@ import org.assertj.core.data.MapEntry;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class TracingInterceptorsTest {
 
@@ -168,10 +169,11 @@ public class TracingInterceptorsTest {
     assertEquals("span should have default name", span.operationName(),
         "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
-    Assertions.assertThat(
-        span.logEntries().stream()
-            .map(logEntry -> (String) logEntry.fields().get(Fields.EVENT))
-            .collect(Collectors.toList()))
+    List<String> events = new ArrayList<>(span.logEntries().size());
+    for (MockSpan.LogEntry logEntry : span.logEntries()) {
+      events.add((String) logEntry.fields().get(Fields.EVENT));
+    }
+    Assertions.assertThat(events)
         .as("span should contain verbose log fields")
         .contains(
             GrpcFields.SERVER_CALL_LISTENER_ON_MESSAGE,
@@ -207,10 +209,11 @@ public class TracingInterceptorsTest {
     assertEquals("span should have default name", span.operationName(),
         "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
-    Assertions.assertThat(
-        span.logEntries().stream()
-            .map(logEntry -> (String) logEntry.fields().get(Fields.EVENT))
-            .collect(Collectors.toList()))
+    List<String> events = new ArrayList<>(span.logEntries().size());
+    for (MockSpan.LogEntry logEntry : span.logEntries()) {
+      events.add((String) logEntry.fields().get(Fields.EVENT));
+    }
+    Assertions.assertThat(events)
         .as("span should contain streaming log fields")
         .contains(
             GrpcFields.SERVER_CALL_LISTENER_ON_MESSAGE,
@@ -416,10 +419,11 @@ public class TracingInterceptorsTest {
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     System.out.println(span.logEntries());
-    Assertions.assertThat(
-        span.logEntries().stream()
-            .map(logEntry -> (String) logEntry.fields().get(Fields.EVENT))
-            .collect(Collectors.toList()))
+    List<String> events = new ArrayList<>(span.logEntries().size());
+    for (MockSpan.LogEntry logEntry : span.logEntries()) {
+      events.add((String) logEntry.fields().get(Fields.EVENT));
+    }
+    Assertions.assertThat(events)
         .as("span should contain verbose log fields")
         .contains(
             GrpcFields.CLIENT_CALL_START,
@@ -451,10 +455,11 @@ public class TracingInterceptorsTest {
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
-    Assertions.assertThat(
-        span.logEntries().stream()
-            .map(logEntry -> (String) logEntry.fields().get(Fields.EVENT))
-            .collect(Collectors.toList()))
+    List<String> events = new ArrayList<>(span.logEntries().size());
+    for (MockSpan.LogEntry logEntry : span.logEntries()) {
+      events.add((String) logEntry.fields().get(Fields.EVENT));
+    }
+    Assertions.assertThat(events)
         .as("span should contain streaming log fields")
         .contains(
             GrpcFields.CLIENT_CALL_SEND_MESSAGE,

--- a/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
@@ -93,7 +93,7 @@ public class TracingInterceptorsTest {
 
     ServerTracingInterceptor tracingInterceptor = new ServerTracingInterceptor(serverTracer);
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -119,8 +119,8 @@ public class TracingInterceptorsTest {
     ServerTracingInterceptor tracingInterceptor = new ServerTracingInterceptor(serverTracer);
     SecondServerInterceptor secondServerInterceptor = new SecondServerInterceptor(serverTracer);
 
-    service.addGreeterServiceWithTwoInterceptors(tracingInterceptor, secondServerInterceptor,
-        grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(
+        grpcServer.getServiceRegistry(), secondServerInterceptor, tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -148,7 +148,7 @@ public class TracingInterceptorsTest {
         .withVerbosity()
         .build();
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -176,7 +176,7 @@ public class TracingInterceptorsTest {
         .withStreaming()
         .build();
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -210,7 +210,7 @@ public class TracingInterceptorsTest {
         })
         .build();
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -238,7 +238,7 @@ public class TracingInterceptorsTest {
         .withTracedAttributes(ServerTracingInterceptor.ServerRequestAttribute.values())
         .build();
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -278,7 +278,7 @@ public class TracingInterceptorsTest {
         .withServerSpanDecorator(serverSpanDecorator)
         .build();
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -315,7 +315,7 @@ public class TracingInterceptorsTest {
         .withServerCloseDecorator(serverCloseDecorator)
         .build();
 
-    service.addGreeterServiceWithInterceptor(tracingInterceptor, grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
 
@@ -556,8 +556,7 @@ public class TracingInterceptorsTest {
 
     ServerTracingInterceptor serverTracingInterceptor = new ServerTracingInterceptor(serverTracer);
 
-    service.addGreeterServiceWithInterceptor(serverTracingInterceptor,
-        grpcServer.getServiceRegistry());
+    service.addGreeterServiceWithInterceptors(grpcServer.getServiceRegistry(), serverTracingInterceptor);
 
     assertTrue("call should complete", client.greet("world"));
     assertEquals("a client span should have been created for the request",


### PR DESCRIPTION
Hi, I work with @yurishkuro at Uber.  I am creating this pull request to fix the following issues:

1. Ensure the span is activated throughout the client call interceptor chain:
    - Span activation was missing from the following client interceptor interface methods:
        - `ClientInterceptor.interceptCall()`
        - `ClientCall.start()`
        - `ClientCall.request()`
        - `ClientCall.cancel()`
        - `ClientCall.halfClose()`
        - `ClientCall.sendMessage()`
        - `ClientCall.isReady()`
        - `ClientCall.setMessageCompression()`
        - `ClientCall.getAttributes()`

2. Ensure the span is activated throughout the server call interceptor chain:
    - Span activation was missing from the following server interceptor interface methods:
        - `ServerCall.Listener.onReady()`

3. Ensure that `GrpcTags` implement and use the `io.opentracing.tag.AbstractTag` interface.

4. Ensure the span logs follow the opentracing semantic conventions:
    - Use log fields defined by https://github.com/opentracing/specification/blob/master/semantic_conventions.md, i.e. `event`, `message`, `error.kind`, `error.object`, etc.
    - Added the following client span log messages on `verbose` or `streaming`:
        - `ClientCall.start()`: `"Client call started"` (`verbose`)
        - `ClientCall.cancel()`: `"Client call canceled"` (`verbose`)
        - `ClientCall.halfClose()`: `"Client sent all messages"` (`verbose` || `streaming`)
        - `ClientCall.sendMessage()`: `"Client sent message"` (`verbose` || `streaming`)
        - `ClientCall.Listener.onHeaders()`: `"Client received response headers"` (`verbose`)
        - `ClientCall.Listener.onMessage()`: `"Client received response message"` (`verbose` || `streaming`)
        - `ClientCall.Listener.onClose()`: `"Client call closed"` (`verbose`)
    - Added the following server span log messages: (`verbose`)
        - `ServerCall.sendHeaders()`: `"Server sent response headers"` (`verbose`)
        - `ServerCall.sendMessage()`: `"Server sent response message"` (`verbose` || `streaming`)
        - `ServerCall.close()`: `"Server call closed"` (`verbose`)
        - `ServerCall.Listener.onMessage()`: `"Server received message"` (`verbose` || `streaming`)
        - `ServerCall.Listener.onHalfClose()`: `"Server received all messages"` (`verbose` || `streaming`)
        - `ServerCall.Listener.onCancel()`: `"Server call cancelled"` (`verbose`)
        - `ServerCall.Listener.onComplete()`: `"Server call completed"` (`verbose`)
