### PR TITLE
Fixed builder & default to tracer.activeSpan().context() source

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ A `TracingServerInterceptor` uses default settings, which you can override by cr
 A `TracingClientInterceptor` also has default settings, which you can override by creating it using a `TracingClientInterceptor.Builder`.
 
 - `withOperationName(String operationName)`: Define how the operation name is constructed for all spans created for this intercepted client. Default is the name of the RPC method. More details in the `Operation Name` section.
-- `withActiveSpanSource(ActiveSpanSource activeSpanSource)`: Define how to extract the current active span, if any. This is needed if you want your client to continue a trace instead of starting a new one. More details in the `Active Span Sources` section.
-- `withActiveSpanContextSource(ActiveSpanContextSource activeSpanContextSource)`: Define how to extract the current active span context, if any. This is needed if you want your client to continue a trace instead of starting a new one. More details in the `Active Span Context Sources` section.
+- `withActiveSpanSource(ActiveSpanSource activeSpanSource)`: Define how to extract the current active span, if any. More details in the `Active Span Sources` section.
+- `withActiveSpanContextSource(ActiveSpanContextSource activeSpanContextSource)`: Define how to extract the current active span context, if any. More details in the `Active Span Context Sources` section.
 - `withStreaming()`: Logs to the client span whenever a message is sent or a response is received. *Note:* This package supports streaming but has not been rigorously tested. If you come across any issues, please let us know.
 - `withVerbosity()`: Logs to the client span additional events, such as call started, message sent, half close (client finished sending messages), response received, and call complete. Default only logs if a call is cancelled.
 - `withTracedAttributes(ClientRequestAttribute... attrs)`: Sets tags on the client span in case you want to track information about the RPC call. See ClientRequestAttribute.java for a list of traceable request attributes.
@@ -237,8 +237,8 @@ import io.opentracing.Span;
 
 We also provide two built-in implementations:
 
-- `ActiveSpanSource.GRPC_CONTEXT` uses the current `io.grpc.Context` and returns the active span for `OpenTracingContextKey`. This is the default active span source.
-- `ActiveSpanSource.NONE` always returns null as the active span, which means the client will always start a new trace
+- `ActiveSpanSource.GRPC_CONTEXT` uses the current `io.grpc.Context` and returns the active span for `OpenTracingContextKey`. 
+- `ActiveSpanSource.NONE` always returns null as the active span, which means the client will retrieve the span from `io.opentracing.Tracer.activeSpan()`. This is the default active span source.
 
 ## Active Span Context Sources
 
@@ -263,7 +263,7 @@ import io.opentracing.Span;
 We also provide two built-in implementations:
 
 - `ActiveSpanContextSource.GRPC_CONTEXT` uses the current `io.grpc.Context` and returns the active span context for `OpenTracingContextKey`.
-- `ActiveSpanContextSource.NONE` always returns null as the active span context, which means the client will always start a new trace
+- `ActiveSpanContextSource.NONE` always returns null as the active span context, which means the client will retrieve the span from `io.opentracing.Tracer.activeSpan().context()`. This is the default active span context source.
 
 ## Custom Span Decorators
 

--- a/src/main/java/io/opentracing/contrib/grpc/ActiveSpanContextSource.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ActiveSpanContextSource.java
@@ -16,31 +16,29 @@ package io.opentracing.contrib.grpc;
 
 import io.opentracing.SpanContext;
 
-/**
- * An interface that defines how to get the current active span context.
- */
+/** An interface that defines how to get the current active span context. */
 public interface ActiveSpanContextSource {
 
-  /**
-   * ActiveSpanContextSource implementation that always returns null as the active span context.
-   */
-  ActiveSpanContextSource NONE = new ActiveSpanContextSource() {
-    @Override
-    public SpanContext getActiveSpanContext() {
-      return null;
-    }
-  };
+  /** ActiveSpanContextSource implementation that always returns null as the active span context. */
+  ActiveSpanContextSource NONE =
+      new ActiveSpanContextSource() {
+        @Override
+        public SpanContext getActiveSpanContext() {
+          return null;
+        }
+      };
 
   /**
    * ActiveSpanContextSource implementation that returns the current span context stored in the GRPC
    * context under {@link OpenTracingContextKey}.
    */
-  ActiveSpanContextSource GRPC_CONTEXT = new ActiveSpanContextSource() {
-    @Override
-    public SpanContext getActiveSpanContext() {
-      return OpenTracingContextKey.activeSpanContext();
-    }
-  };
+  ActiveSpanContextSource GRPC_CONTEXT =
+      new ActiveSpanContextSource() {
+        @Override
+        public SpanContext getActiveSpanContext() {
+          return OpenTracingContextKey.activeSpanContext();
+        }
+      };
 
   /**
    * Retrieves the active {@link SpanContext}.
@@ -48,5 +46,4 @@ public interface ActiveSpanContextSource {
    * @return the active span context
    */
   SpanContext getActiveSpanContext();
-
 }

--- a/src/main/java/io/opentracing/contrib/grpc/ActiveSpanSource.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ActiveSpanSource.java
@@ -16,31 +16,29 @@ package io.opentracing.contrib.grpc;
 
 import io.opentracing.Span;
 
-/**
- * An interface that defines how to get the current active span.
- */
+/** An interface that defines how to get the current active span. */
 public interface ActiveSpanSource {
 
-  /**
-   * ActiveSpanSource implementation that always returns null as the active span.
-   */
-  ActiveSpanSource NONE = new ActiveSpanSource() {
-    @Override
-    public Span getActiveSpan() {
-      return null;
-    }
-  };
+  /** ActiveSpanSource implementation that always returns null as the active span. */
+  ActiveSpanSource NONE =
+      new ActiveSpanSource() {
+        @Override
+        public Span getActiveSpan() {
+          return null;
+        }
+      };
 
   /**
    * ActiveSpanSource implementation that returns the current span stored in the GRPC context under
    * {@link OpenTracingContextKey}.
    */
-  ActiveSpanSource GRPC_CONTEXT = new ActiveSpanSource() {
-    @Override
-    public Span getActiveSpan() {
-      return OpenTracingContextKey.activeSpan();
-    }
-  };
+  ActiveSpanSource GRPC_CONTEXT =
+      new ActiveSpanSource() {
+        @Override
+        public Span getActiveSpan() {
+          return OpenTracingContextKey.activeSpan();
+        }
+      };
 
   /**
    * Retieves the active {@link Span}.

--- a/src/main/java/io/opentracing/contrib/grpc/ClientCloseDecorator.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ClientCloseDecorator.java
@@ -25,8 +25,8 @@ public interface ClientCloseDecorator {
    * The method of the implementation is executed inside {@link
    * ForwardingClientCallListener#onClose}.
    *
-   * @param span     The span created by {@link TracingClientInterceptor}
-   * @param status   The status passed to {@link ForwardingClientCallListener#onClose}.
+   * @param span The span created by {@link TracingClientInterceptor}
+   * @param status The status passed to {@link ForwardingClientCallListener#onClose}.
    * @param trailers The trailing headers passed to {@link ForwardingClientCallListener#onClose}.
    */
   void close(Span span, Status status, Metadata trailers);

--- a/src/main/java/io/opentracing/contrib/grpc/ClientSpanDecorator.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ClientSpanDecorator.java
@@ -29,11 +29,11 @@ public interface ClientSpanDecorator {
    * The method of the implementation is executed inside {@link
    * TracingClientInterceptor#interceptCall}.
    *
-   * @param span        The span created by {@link TracingClientInterceptor}
+   * @param span The span created by {@link TracingClientInterceptor}
    * @param callOptions The {@link ServerCall} parameter of {@link
-   *                    TracingClientInterceptor#interceptCall}
-   * @param method      The {@link MethodDescriptor} parameter of {@link
-   *                    TracingClientInterceptor#interceptCall}
+   *     TracingClientInterceptor#interceptCall}
+   * @param method The {@link MethodDescriptor} parameter of {@link
+   *     TracingClientInterceptor#interceptCall}
    */
   void interceptCall(Span span, MethodDescriptor method, CallOptions callOptions);
 }

--- a/src/main/java/io/opentracing/contrib/grpc/GrpcFields.java
+++ b/src/main/java/io/opentracing/contrib/grpc/GrpcFields.java
@@ -50,8 +50,8 @@ final class GrpcFields {
   }
 
   private static void logCallError(Span span, String message, Throwable cause, String name) {
-    ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
-        .put(Fields.EVENT, GrpcFields.ERROR);
+    ImmutableMap.Builder<String, Object> builder =
+        ImmutableMap.<String, Object>builder().put(Fields.EVENT, GrpcFields.ERROR);
     String causeMessage = null;
     if (cause != null) {
       builder.put(Fields.ERROR_OBJECT, cause);

--- a/src/main/java/io/opentracing/contrib/grpc/GrpcTags.java
+++ b/src/main/java/io/opentracing/contrib/grpc/GrpcTags.java
@@ -30,106 +30,85 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.concurrent.TimeUnit;
 
-/**
- * Package private utility methods for common gRPC tags.
- */
+/** Package private utility methods for common gRPC tags. */
 final class GrpcTags {
 
-  /**
-   * grpc.authority tag.
-   */
+  /** grpc.authority tag. */
   static final NullableTag<String> GRPC_AUTHORITY = new NullableTag<>("grpc.authority");
 
-  /**
-   * grpc.call_attributes tag.
-   */
-  static final NullableTag<Attributes> GRPC_CALL_ATTRIBUTES = new NullableTag<>(
-      "grpc.call_attributes");
+  /** grpc.call_attributes tag. */
+  static final NullableTag<Attributes> GRPC_CALL_ATTRIBUTES =
+      new NullableTag<>("grpc.call_attributes");
 
-  /**
-   * grpc.call_options tag.
-   */
+  /** grpc.call_options tag. */
   static final NullableTag<CallOptions> GRPC_CALL_OPTIONS = new NullableTag<>("grpc.call_options");
 
-  /**
-   * grpc.compressor tag.
-   */
+  /** grpc.compressor tag. */
   static final NullableTag<String> GRPC_COMPRESSOR = new NullableTag<>("grpc.compressor");
 
-  /**
-   * grpc.deadline_millis tag.
-   */
-  static final Tag<Deadline> GRPC_DEADLINE = new AbstractTag<Deadline>("grpc.deadline_millis") {
-    @Override
-    public void set(Span span, Deadline deadline) {
-      if (deadline != null) {
-        span.setTag(super.key, String.valueOf(deadline.timeRemaining(TimeUnit.MILLISECONDS)));
-      }
-    }
-  };
+  /** grpc.deadline_millis tag. */
+  static final Tag<Deadline> GRPC_DEADLINE =
+      new AbstractTag<Deadline>("grpc.deadline_millis") {
+        @Override
+        public void set(Span span, Deadline deadline) {
+          if (deadline != null) {
+            span.setTag(super.key, String.valueOf(deadline.timeRemaining(TimeUnit.MILLISECONDS)));
+          }
+        }
+      };
 
-  /**
-   * grpc.headers tag.
-   */
+  /** grpc.headers tag. */
   static final NullableTag<Metadata> GRPC_HEADERS = new NullableTag<>("grpc.headers");
 
-  /**
-   * grpc.method_name tag.
-   */
-  static final Tag<MethodDescriptor> GRPC_METHOD_NAME = new AbstractTag<MethodDescriptor>(
-      "grpc.method_name") {
-    @Override
-    public void set(Span span, MethodDescriptor method) {
-      if (method != null) {
-        span.setTag(super.key, method.getFullMethodName());
-      }
-    }
-  };
+  /** grpc.method_name tag. */
+  static final Tag<MethodDescriptor> GRPC_METHOD_NAME =
+      new AbstractTag<MethodDescriptor>("grpc.method_name") {
+        @Override
+        public void set(Span span, MethodDescriptor method) {
+          if (method != null) {
+            span.setTag(super.key, method.getFullMethodName());
+          }
+        }
+      };
 
-  /**
-   * grpc.method_type tag.
-   */
-  static final Tag<MethodDescriptor> GRPC_METHOD_TYPE = new AbstractTag<MethodDescriptor>(
-      "grpc.method_type") {
-    @Override
-    public void set(Span span, MethodDescriptor method) {
-      if (method != null) {
-        span.setTag(super.key, method.getType().toString());
-      }
-    }
-  };
+  /** grpc.method_type tag. */
+  static final Tag<MethodDescriptor> GRPC_METHOD_TYPE =
+      new AbstractTag<MethodDescriptor>("grpc.method_type") {
+        @Override
+        public void set(Span span, MethodDescriptor method) {
+          if (method != null) {
+            span.setTag(super.key, method.getType().toString());
+          }
+        }
+      };
 
-  /**
-   * grpc.status tag.
-   */
-  static final Tag<Status> GRPC_STATUS = new AbstractTag<Status>("grpc.status") {
-    @Override
-    public void set(Span span, Status status) {
-      if (status != null) {
-        span.setTag(super.key, status.getCode().name());
-      }
-    }
-  };
+  /** grpc.status tag. */
+  static final Tag<Status> GRPC_STATUS =
+      new AbstractTag<Status>("grpc.status") {
+        @Override
+        public void set(Span span, Status status) {
+          if (status != null) {
+            span.setTag(super.key, status.getCode().name());
+          }
+        }
+      };
 
-  /**
-   * peer.address tag.
-   */
-  static final Tag<Attributes> PEER_ADDRESS = new AbstractTag<Attributes>("peer.address") {
-    @Override
-    public void set(Span span, Attributes attributes) {
-      SocketAddress address = attributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
-      if (address instanceof InProcessSocketAddress) {
-        span.setTag(super.key, ((InProcessSocketAddress) address).getName());
-      } else if (address instanceof InetSocketAddress) {
-        final InetSocketAddress inetAddress = (InetSocketAddress) address;
-        span.setTag(super.key, inetAddress.getHostString() + ':' + inetAddress.getPort());
-      }
-    }
-  };
+  /** peer.address tag. */
+  static final Tag<Attributes> PEER_ADDRESS =
+      new AbstractTag<Attributes>("peer.address") {
+        @Override
+        public void set(Span span, Attributes attributes) {
+          SocketAddress address = attributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR);
+          if (address instanceof InProcessSocketAddress) {
+            span.setTag(super.key, ((InProcessSocketAddress) address).getName());
+          } else if (address instanceof InetSocketAddress) {
+            final InetSocketAddress inetAddress = (InetSocketAddress) address;
+            span.setTag(super.key, inetAddress.getHostString() + ':' + inetAddress.getPort());
+          }
+        }
+      };
 
-  /**
-   * Value for {@link Tags#COMPONENT} for gRPC.
-   */
+  /** Value for {@link Tags#COMPONENT} for gRPC. */
   static final String COMPONENT_NAME = "java-grpc";
 
   static class NullableTag<T> extends AbstractTag<T> {

--- a/src/main/java/io/opentracing/contrib/grpc/OperationNameConstructor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/OperationNameConstructor.java
@@ -16,27 +16,26 @@ package io.opentracing.contrib.grpc;
 
 import io.grpc.MethodDescriptor;
 
-/**
- * Interface that allows span operation names to be constructed from an RPC's method descriptor.
- */
+/** Interface that allows span operation names to be constructed from an RPC's method descriptor. */
 public interface OperationNameConstructor {
 
   /**
    * Default span operation name constructor, that will return an RPC's method name when
    * constructOperationName is called.
    */
-  OperationNameConstructor DEFAULT = new OperationNameConstructor() {
-    @Override
-    public <ReqT, RespT> String constructOperationName(MethodDescriptor<ReqT, RespT> method) {
-      return method.getFullMethodName();
-    }
-  };
+  OperationNameConstructor DEFAULT =
+      new OperationNameConstructor() {
+        @Override
+        public <ReqT, RespT> String constructOperationName(MethodDescriptor<ReqT, RespT> method) {
+          return method.getFullMethodName();
+        }
+      };
 
   /**
    * Constructs a span's operation name from the RPC's method.
    *
-   * @param method  the rpc method to extract a name from
-   * @param <ReqT>  the rpc request type
+   * @param method the rpc method to extract a name from
+   * @param <ReqT> the rpc request type
    * @param <RespT> the rpc response type
    * @return the operation name
    */

--- a/src/main/java/io/opentracing/contrib/grpc/ServerCloseDecorator.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ServerCloseDecorator.java
@@ -30,8 +30,8 @@ public interface ServerCloseDecorator {
    * The method of the implementation is executed inside {@link ForwardingServerCall#close(Status,
    * Metadata)}.
    *
-   * @param span     The span created by {@link TracingServerInterceptor}
-   * @param status   The status passed to {@link ServerCall#close(Status, Metadata)}.
+   * @param span The span created by {@link TracingServerInterceptor}
+   * @param status The status passed to {@link ServerCall#close(Status, Metadata)}.
    * @param trailers The trailing headers passed to {@link ServerCall#close(Status, Metadata)}
    */
   void close(Span span, Status status, Metadata trailers);

--- a/src/main/java/io/opentracing/contrib/grpc/ServerSpanDecorator.java
+++ b/src/main/java/io/opentracing/contrib/grpc/ServerSpanDecorator.java
@@ -28,9 +28,8 @@ public interface ServerSpanDecorator {
    * The method of the implementation is executed inside {@link
    * TracingServerInterceptor#interceptCall}.
    *
-   * @param span    The span created by {@link TracingServerInterceptor}
-   * @param call    The {@link ServerCall} parameter of {@link
-   *                TracingServerInterceptor#interceptCall}
+   * @param span The span created by {@link TracingServerInterceptor}
+   * @param call The {@link ServerCall} parameter of {@link TracingServerInterceptor#interceptCall}
    * @param headers The {@link Metadata} parameter of {@link TracingServerInterceptor#interceptCall}
    */
   void interceptCall(Span span, ServerCall call, Metadata headers);

--- a/src/test/java/io/opentracing/contrib/grpc/ActiveSpanContextSourceTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/ActiveSpanContextSourceTest.java
@@ -28,7 +28,7 @@ public class ActiveSpanContextSourceTest {
   private final MockTracer tracer = new MockTracer();
 
   @Before
-  public void before() {
+  public void setUp() {
     tracer.reset();
   }
 

--- a/src/test/java/io/opentracing/contrib/grpc/ActiveSpanContextSourceTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/ActiveSpanContextSourceTest.java
@@ -50,22 +50,25 @@ public class ActiveSpanContextSourceTest {
   @Test
   public void testDefaultGrpc() {
     ActiveSpanContextSource ss = ActiveSpanContextSource.GRPC_CONTEXT;
-    assertNull("active span context should be null, no span context in OpenTracingContextKey",
+    assertNull(
+        "active span context should be null, no span context in OpenTracingContextKey",
         ss.getActiveSpanContext());
 
     Span span = tracer.buildSpan("s0").start();
-    Context ctx = Context.current()
-        .withValue(OpenTracingContextKey.getSpanContextKey(), span.context());
+    Context ctx =
+        Context.current().withValue(OpenTracingContextKey.getSpanContextKey(), span.context());
     Context previousCtx = ctx.attach();
 
-    assertEquals("active span context should be OpenTracingContextKey.activeSpanContext()",
-        ss.getActiveSpanContext(), span.context());
+    assertEquals(
+        "active span context should be OpenTracingContextKey.activeSpanContext()",
+        ss.getActiveSpanContext(),
+        span.context());
 
     ctx.detach(previousCtx);
     span.finish();
 
-    assertNull("active span context should be null, no span context in OpenTracingContextKey",
+    assertNull(
+        "active span context should be null, no span context in OpenTracingContextKey",
         ss.getActiveSpanContext());
   }
-
 }

--- a/src/test/java/io/opentracing/contrib/grpc/ActiveSpanSourceTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/ActiveSpanSourceTest.java
@@ -51,13 +51,12 @@ public class ActiveSpanSourceTest {
     Context ctx = Context.current().withValue(OpenTracingContextKey.getKey(), span);
     Context previousCtx = ctx.attach();
 
-    assertEquals("active span should be OpenTracingContextKey.activeSpan()", ss.getActiveSpan(),
-        span);
+    assertEquals(
+        "active span should be OpenTracingContextKey.activeSpan()", ss.getActiveSpan(), span);
 
     ctx.detach(previousCtx);
     span.finish();
 
     assertNull("active span should be null, no span in OpenTracingContextKey", ss.getActiveSpan());
   }
-
 }

--- a/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/GrpcTagsTest.java
@@ -50,24 +50,23 @@ public class GrpcTagsTest {
 
   @Test
   public void testPeerAddressSocket() {
-    final InetSocketAddress address = new InetSocketAddress("127.0.0.1",
-        ThreadLocalRandom.current().nextInt(65535));
-    final Attributes attributes = Attributes.newBuilder()
-        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, address)
-        .build();
+    final InetSocketAddress address =
+        new InetSocketAddress("127.0.0.1", ThreadLocalRandom.current().nextInt(65535));
+    final Attributes attributes =
+        Attributes.newBuilder().set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, address).build();
     MockSpan span = new MockTracer().buildSpan("").start();
     GrpcTags.PEER_ADDRESS.set(span, attributes);
     assertThat(span.tags())
-        .containsOnly(MapEntry.entry(GrpcTags.PEER_ADDRESS.getKey(),
-            address.getHostString() + ':' + address.getPort()));
+        .containsOnly(
+            MapEntry.entry(
+                GrpcTags.PEER_ADDRESS.getKey(), address.getHostString() + ':' + address.getPort()));
   }
 
   @Test
   public void testPeerAddressInProcess() {
     final InProcessSocketAddress address = new InProcessSocketAddress(UUID.randomUUID().toString());
-    final Attributes attributes = Attributes.newBuilder()
-        .set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, address)
-        .build();
+    final Attributes attributes =
+        Attributes.newBuilder().set(Grpc.TRANSPORT_ATTR_REMOTE_ADDR, address).build();
     MockSpan span = new MockTracer().buildSpan("").start();
     GrpcTags.PEER_ADDRESS.set(span, attributes);
     assertThat(span.tags())

--- a/src/test/java/io/opentracing/contrib/grpc/OpenTracingContextKeyTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/OpenTracingContextKeyTest.java
@@ -30,7 +30,7 @@ public class OpenTracingContextKeyTest {
   private final MockTracer tracer = new MockTracer();
 
   @Before
-  public void before() {
+  public void setUp() {
     tracer.reset();
   }
 

--- a/src/test/java/io/opentracing/contrib/grpc/OpenTracingContextKeyTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/OpenTracingContextKeyTest.java
@@ -43,19 +43,21 @@ public class OpenTracingContextKeyTest {
   @Test
   public void testGetSpanContextKey() {
     Key<SpanContext> key = OpenTracingContextKey.getSpanContextKey();
-    assertEquals("Key should have correct name", key.toString(),
-        OpenTracingContextKey.KEY_CONTEXT_NAME);
+    assertEquals(
+        "Key should have correct name", key.toString(), OpenTracingContextKey.KEY_CONTEXT_NAME);
   }
 
   @Test
   public void testNoActiveSpan() {
-    assertNull("activeSpan() should return null when no span is active",
+    assertNull(
+        "activeSpan() should return null when no span is active",
         OpenTracingContextKey.activeSpan());
   }
 
   @Test
   public void testNoActiveSpanContext() {
-    assertNull("activeSpanContext() should return null when no span context is active",
+    assertNull(
+        "activeSpanContext() should return null when no span context is active",
         OpenTracingContextKey.activeSpanContext());
   }
 
@@ -76,8 +78,8 @@ public class OpenTracingContextKeyTest {
   @Test
   public void testGetActiveSpanContext() {
     Span span = tracer.buildSpan("s0").start();
-    Context ctx = Context.current().withValue(OpenTracingContextKey.getSpanContextKey(),
-        span.context());
+    Context ctx =
+        Context.current().withValue(OpenTracingContextKey.getSpanContextKey(), span.context());
     Context previousCtx = ctx.attach();
 
     assertEquals(OpenTracingContextKey.activeSpanContext(), span.context());
@@ -111,13 +113,14 @@ public class OpenTracingContextKeyTest {
   @Test
   public void testMultipleContextLayersForSpanContext() {
     Span parentSpan = tracer.buildSpan("s0").start();
-    Context parentCtx = Context.current().withValue(OpenTracingContextKey.getSpanContextKey(),
-        parentSpan.context());
+    Context parentCtx =
+        Context.current()
+            .withValue(OpenTracingContextKey.getSpanContextKey(), parentSpan.context());
     Context previousCtx = parentCtx.attach();
 
     Span childSpan = tracer.buildSpan("s1").start();
-    Context childCtx = Context.current().withValue(OpenTracingContextKey.getSpanContextKey(),
-        childSpan.context());
+    Context childCtx =
+        Context.current().withValue(OpenTracingContextKey.getSpanContextKey(), childSpan.context());
     parentCtx = childCtx.attach();
     assertEquals(OpenTracingContextKey.activeSpanContext(), childSpan.context());
 

--- a/src/test/java/io/opentracing/contrib/grpc/SecondClientInterceptor.java
+++ b/src/test/java/io/opentracing/contrib/grpc/SecondClientInterceptor.java
@@ -16,7 +16,6 @@ package io.opentracing.contrib.grpc;
 
 import static org.junit.Assert.assertNotNull;
 
-import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -38,9 +37,7 @@ public class SecondClientInterceptor implements ClientInterceptor {
 
   @Override
   public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-      MethodDescriptor<ReqT, RespT> method,
-      CallOptions callOptions,
-      Channel next) {
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
 
     assertNotNull(tracer.activeSpan());
 
@@ -50,51 +47,34 @@ public class SecondClientInterceptor implements ClientInterceptor {
       @Override
       public void start(Listener<RespT> responseListener, Metadata headers) {
         assertNotNull(tracer.activeSpan());
-        delegate().start(new ForwardingClientCallListener
-            .SimpleForwardingClientCallListener<RespT>(responseListener) {
-        }, headers);
+        super.start(
+            new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+                responseListener) {},
+            headers);
       }
 
       @Override
       public void request(int numMessages) {
         assertNotNull(tracer.activeSpan());
-        delegate().request(numMessages);
-      }
-
-      @Override
-      public void cancel(@Nullable String message, @Nullable Throwable cause) {
-        assertNotNull(tracer.activeSpan());
-        delegate().cancel(message, cause);
-      }
-
-      @Override
-      public void halfClose() {
-        assertNotNull(tracer.activeSpan());
-        delegate().halfClose();
+        super.request(numMessages);
       }
 
       @Override
       public void sendMessage(ReqT message) {
         assertNotNull(tracer.activeSpan());
-        delegate().sendMessage(message);
+        super.sendMessage(message);
       }
 
       @Override
-      public boolean isReady() {
+      public void halfClose() {
         assertNotNull(tracer.activeSpan());
-        return delegate().isReady();
+        super.halfClose();
       }
 
       @Override
-      public void setMessageCompression(boolean enabled) {
+      public void cancel(@Nullable String message, @Nullable Throwable cause) {
         assertNotNull(tracer.activeSpan());
-        delegate().setMessageCompression(enabled);
-      }
-
-      @Override
-      public Attributes getAttributes() {
-        assertNotNull(tracer.activeSpan());
-        return delegate().getAttributes();
+        super.cancel(message, cause);
       }
     };
   }

--- a/src/test/java/io/opentracing/contrib/grpc/SecondClientInterceptor.java
+++ b/src/test/java/io/opentracing/contrib/grpc/SecondClientInterceptor.java
@@ -54,12 +54,6 @@ public class SecondClientInterceptor implements ClientInterceptor {
       }
 
       @Override
-      public void request(int numMessages) {
-        assertNotNull(tracer.activeSpan());
-        super.request(numMessages);
-      }
-
-      @Override
       public void sendMessage(ReqT message) {
         assertNotNull(tracer.activeSpan());
         super.sendMessage(message);

--- a/src/test/java/io/opentracing/contrib/grpc/SecondServerInterceptor.java
+++ b/src/test/java/io/opentracing/contrib/grpc/SecondServerInterceptor.java
@@ -16,7 +16,6 @@ package io.opentracing.contrib.grpc;
 
 import static org.junit.Assert.assertNotNull;
 
-import io.grpc.Attributes;
 import io.grpc.ForwardingServerCall;
 import io.grpc.ForwardingServerCallListener;
 import io.grpc.Metadata;
@@ -37,106 +36,63 @@ public class SecondServerInterceptor implements ServerInterceptor {
 
   @Override
   public <ReqT, RespT> Listener<ReqT> interceptCall(
-      ServerCall<ReqT, RespT> call,
-      Metadata headers,
-      ServerCallHandler<ReqT, RespT> next) {
+      ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
 
     assertNotNull(tracer.activeSpan());
 
-    call = new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+    call =
+        new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
 
-      @Override
-      public void request(int numMessages) {
-        assertNotNull(tracer.activeSpan());
-        delegate().request(numMessages);
-      }
+          @Override
+          public void sendHeaders(Metadata headers) {
+            assertNotNull(tracer.activeSpan());
+            super.sendHeaders(headers);
+          }
 
-      @Override
-      public void sendHeaders(Metadata headers) {
-        assertNotNull(tracer.activeSpan());
-        delegate().sendHeaders(headers);
-      }
+          @Override
+          public void sendMessage(RespT message) {
+            assertNotNull(tracer.activeSpan());
+            super.sendMessage(message);
+          }
 
-      @Override
-      public void sendMessage(RespT message) {
-        assertNotNull(tracer.activeSpan());
-        delegate().sendMessage(message);
-      }
-
-      @Override
-      public boolean isReady() {
-        assertNotNull(tracer.activeSpan());
-        return delegate().isReady();
-      }
-
-      @Override
-      public void close(Status status, Metadata trailers) {
-        assertNotNull(tracer.activeSpan());
-        delegate().close(status, trailers);
-      }
-
-      @Override
-      public boolean isCancelled() {
-        assertNotNull(tracer.activeSpan());
-        return delegate().isCancelled();
-      }
-
-      @Override
-      public void setMessageCompression(boolean enabled) {
-        assertNotNull(tracer.activeSpan());
-        delegate().setMessageCompression(enabled);
-      }
-
-      @Override
-      public void setCompression(String compressor) {
-        assertNotNull(tracer.activeSpan());
-        delegate().setCompression(compressor);
-      }
-
-      @Override
-      public Attributes getAttributes() {
-        assertNotNull(tracer.activeSpan());
-        return delegate().getAttributes();
-      }
-
-      @Override
-      public String getAuthority() {
-        assertNotNull(tracer.activeSpan());
-        return delegate().getAuthority();
-      }
-    };
+          @Override
+          public void close(Status status, Metadata trailers) {
+            assertNotNull(tracer.activeSpan());
+            super.close(status, trailers);
+          }
+        };
 
     return new ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
         next.startCall(call, headers)) {
 
       @Override
+      public void onReady() {
+        assertNotNull(tracer.activeSpan());
+        super.onReady();
+      }
+
+      @Override
       public void onMessage(ReqT message) {
         assertNotNull(tracer.activeSpan());
-        delegate().onMessage(message);
+        super.onMessage(message);
       }
 
       @Override
       public void onHalfClose() {
         assertNotNull(tracer.activeSpan());
-        delegate().onHalfClose();
+        super.onHalfClose();
       }
 
       @Override
       public void onCancel() {
         assertNotNull(tracer.activeSpan());
-        delegate().onCancel();
+        super.onCancel();
       }
 
       @Override
       public void onComplete() {
         assertNotNull(tracer.activeSpan());
-        delegate().onComplete();
-      }
-
-      @Override
-      public void onReady() {
-        assertNotNull(tracer.activeSpan());
-        delegate().onReady();
+        super.onComplete();
       }
     };
   }

--- a/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
@@ -35,9 +35,10 @@ class TracedClient {
       long deadline,
       String compression,
       ClientInterceptor... interceptors) {
-    blockingStub = GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel, interceptors))
-        .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS)
-        .withCompression(compression);
+    blockingStub =
+        GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel, interceptors))
+            .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS)
+            .withCompression(compression);
   }
 
   HelloReply greet() {

--- a/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
@@ -84,7 +84,8 @@ public class TracingClientInterceptorTest {
 
   @Test
   public void testTracedClientBasic() {
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor(clientTracer);
+    TracingClientInterceptor tracingInterceptor =
+        TracingClientInterceptor.newBuilder().withTracer(clientTracer).build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -107,7 +108,8 @@ public class TracingClientInterceptorTest {
   @Test
   public void testTracedClientTwoInterceptors() {
     SecondClientInterceptor secondInterceptor = new SecondClientInterceptor(clientTracer);
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor(clientTracer);
+    TracingClientInterceptor tracingInterceptor =
+        TracingClientInterceptor.newBuilder().withTracer(clientTracer).build();
     TracedClient client =
         new TracedClient(grpcServer.getChannel(), secondInterceptor, tracingInterceptor);
 
@@ -131,7 +133,7 @@ public class TracingClientInterceptorTest {
   @Test
   public void testTracedClientWithVerbosity() {
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+        new TracingClientInterceptor.Builder().withTracer(clientTracer).withVerbosity().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -167,7 +169,7 @@ public class TracingClientInterceptorTest {
   @Test
   public void testTracedClientWithStreaming() {
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withStreaming().build();
+        TracingClientInterceptor.newBuilder().withTracer(clientTracer).withStreaming().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -199,7 +201,8 @@ public class TracingClientInterceptorTest {
   @Test
   public void testTracedClientWithOperationName() {
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer)
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
             .withOperationName(
                 new OperationNameConstructor() {
                   @Override
@@ -232,7 +235,8 @@ public class TracingClientInterceptorTest {
   @Test
   public void testTracedClientWithTracedAttributes() {
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer)
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
             .withTracedAttributes(TracingClientInterceptor.ClientRequestAttribute.values())
             .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), 50, "gzip", tracingInterceptor);
@@ -268,7 +272,8 @@ public class TracingClientInterceptorTest {
           }
         };
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer)
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
             .withActiveSpanSource(activeSpanSource)
             .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
@@ -301,7 +306,8 @@ public class TracingClientInterceptorTest {
           }
         };
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer)
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
             .withActiveSpanContextSource(activeSpanContextSource)
             .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
@@ -343,7 +349,8 @@ public class TracingClientInterceptorTest {
         };
 
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer)
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
             .withClientSpanDecorator(spanTagger)
             .withClientSpanDecorator(spanLogger)
             .build();
@@ -391,7 +398,8 @@ public class TracingClientInterceptorTest {
         };
 
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer)
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
             .withClientCloseDecorator(closeTagger)
             .withClientCloseDecorator(closeLogger)
             .build();

--- a/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
@@ -48,30 +48,32 @@ public class TracingClientInterceptorTest {
 
   private static final String PREFIX = "testing-";
 
-  private static final Map<String, Object> BASE_TAGS = ImmutableMap.<String, Object>builder()
-      .put(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
-      .put(GrpcTags.GRPC_STATUS.getKey(), Status.Code.OK.name())
-      .build();
+  private static final Map<String, Object> BASE_TAGS =
+      ImmutableMap.<String, Object>builder()
+          .put(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
+          .put(GrpcTags.GRPC_STATUS.getKey(), Status.Code.OK.name())
+          .build();
 
-  private static final Map<String, Object> BASE_CLIENT_TAGS = ImmutableMap.<String, Object>builder()
-      .putAll(BASE_TAGS)
-      .put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
-      .build();
+  private static final Map<String, Object> BASE_CLIENT_TAGS =
+      ImmutableMap.<String, Object>builder()
+          .putAll(BASE_TAGS)
+          .put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+          .build();
 
-  private static final Set<String> CLIENT_ATTRIBUTE_TAGS = ImmutableSet.of(
-      GrpcTags.GRPC_CALL_OPTIONS.getKey(),
-      //TODO: @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
-      //GrpcTags.GRPC_AUTHORITY.getKey(),
-      GrpcTags.GRPC_COMPRESSOR.getKey(),
-      GrpcTags.GRPC_DEADLINE.getKey(),
-      GrpcTags.GRPC_METHOD_NAME.getKey(),
-      GrpcTags.GRPC_METHOD_TYPE.getKey(),
-      GrpcTags.GRPC_HEADERS.getKey());
+  private static final Set<String> CLIENT_ATTRIBUTE_TAGS =
+      ImmutableSet.of(
+          GrpcTags.GRPC_CALL_OPTIONS.getKey(),
+          // TODO: @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1767")
+          // GrpcTags.GRPC_AUTHORITY.getKey(),
+          GrpcTags.GRPC_COMPRESSOR.getKey(),
+          GrpcTags.GRPC_DEADLINE.getKey(),
+          GrpcTags.GRPC_METHOD_NAME.getKey(),
+          GrpcTags.GRPC_METHOD_TYPE.getKey(),
+          GrpcTags.GRPC_HEADERS.getKey());
 
   private final MockTracer clientTracer = new MockTracer();
 
-  @Rule
-  public GrpcServerRule grpcServer = new GrpcServerRule();
+  @Rule public GrpcServerRule grpcServer = new GrpcServerRule();
 
   @Before
   public void setUp() {
@@ -85,58 +87,59 @@ public class TracingClientInterceptorTest {
     TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor(clientTracer);
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientTwoInterceptors() {
     SecondClientInterceptor secondInterceptor = new SecondClientInterceptor(clientTracer);
     TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor(clientTracer);
-    TracedClient client = new TracedClient(grpcServer.getChannel(), secondInterceptor,
-        tracingInterceptor);
+    TracedClient client =
+        new TracedClient(grpcServer.getChannel(), secondInterceptor, tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientWithVerbosity() {
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withVerbosity()
-        .build();
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
@@ -155,25 +158,24 @@ public class TracingClientInterceptorTest {
             GrpcFields.CLIENT_CALL_LISTENER_ON_HEADERS,
             GrpcFields.CLIENT_CALL_LISTENER_ON_MESSAGE,
             GrpcFields.CLIENT_CALL_LISTENER_ON_CLOSE);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientWithStreaming() {
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withStreaming()
-        .build();
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withStreaming().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
@@ -188,207 +190,225 @@ public class TracingClientInterceptorTest {
             GrpcFields.CLIENT_CALL_SEND_MESSAGE,
             GrpcFields.CLIENT_CALL_HALF_CLOSE,
             GrpcFields.CLIENT_CALL_LISTENER_ON_MESSAGE);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientWithOperationName() {
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withOperationName(new OperationNameConstructor() {
-          @Override
-          public <ReqT, RespT> String constructOperationName(MethodDescriptor<ReqT, RespT> method) {
-            return PREFIX + method.getFullMethodName();
-          }
-        })
-        .build();
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer)
+            .withOperationName(
+                new OperationNameConstructor() {
+                  @Override
+                  public <ReqT, RespT> String constructOperationName(
+                      MethodDescriptor<ReqT, RespT> method) {
+                    return PREFIX + method.getFullMethodName();
+                  }
+                })
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
-    assertEquals("span should have prefix", span.operationName(),
-        PREFIX + "helloworld.Greeter/SayHello");
+    assertEquals(
+        "span should have prefix", span.operationName(), PREFIX + "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientWithTracedAttributes() {
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withTracedAttributes(TracingClientInterceptor.ClientRequestAttribute.values())
-        .build();
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer)
+            .withTracedAttributes(TracingClientInterceptor.ClientRequestAttribute.values())
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), 50, "gzip", tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .containsAllEntriesOf(BASE_CLIENT_TAGS);
     Assertions.assertThat(span.tags().keySet())
         .as("span should have tags for all client request attributes")
         .containsAll(CLIENT_ATTRIBUTE_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientwithActiveSpanSource() {
     final MockSpan parentSpan = clientTracer.buildSpan("parent").start();
-    ActiveSpanSource activeSpanSource = new ActiveSpanSource() {
-      @Override
-      public Span getActiveSpan() {
-        return parentSpan;
-      }
-    };
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withActiveSpanSource(activeSpanSource)
-        .build();
+    ActiveSpanSource activeSpanSource =
+        new ActiveSpanSource() {
+          @Override
+          public Span getActiveSpan() {
+            return parentSpan;
+          }
+        };
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer)
+            .withActiveSpanSource(activeSpanSource)
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have parent", span.parentId(), parentSpan.context().spanId());
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientwithActiveSpanContextSource() {
     final MockSpan parentSpan = clientTracer.buildSpan("parent").start();
-    ActiveSpanContextSource activeSpanContextSource = new ActiveSpanContextSource() {
-      @Override
-      public SpanContext getActiveSpanContext() {
-        return parentSpan.context();
-      }
-    };
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withActiveSpanContextSource(activeSpanContextSource)
-        .build();
+    ActiveSpanContextSource activeSpanContextSource =
+        new ActiveSpanContextSource() {
+          @Override
+          public SpanContext getActiveSpanContext() {
+            return parentSpan.context();
+          }
+        };
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer)
+            .withActiveSpanContextSource(activeSpanContextSource)
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have parent", span.parentId(), parentSpan.context().spanId());
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base client tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base client tags")
         .isEqualTo(BASE_CLIENT_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientWithClientSpanDecorator() {
-    ClientSpanDecorator spanTagger = new ClientSpanDecorator() {
-      @Override
-      public void interceptCall(Span span, MethodDescriptor method, CallOptions callOptions) {
-        span.setTag("test_tag", "test_value");
-        span.setTag("tag_from_method", method.getFullMethodName());
-        span.setTag("tag_from_call_options", callOptions.getCompressor());
-      }
-    };
-    ClientSpanDecorator spanLogger = new ClientSpanDecorator() {
-      @Override
-      public void interceptCall(Span span, MethodDescriptor method, CallOptions callOptions) {
-        span.log("A span log");
-      }
-    };
+    ClientSpanDecorator spanTagger =
+        new ClientSpanDecorator() {
+          @Override
+          public void interceptCall(Span span, MethodDescriptor method, CallOptions callOptions) {
+            span.setTag("test_tag", "test_value");
+            span.setTag("tag_from_method", method.getFullMethodName());
+            span.setTag("tag_from_call_options", callOptions.getCompressor());
+          }
+        };
+    ClientSpanDecorator spanLogger =
+        new ClientSpanDecorator() {
+          @Override
+          public void interceptCall(Span span, MethodDescriptor method, CallOptions callOptions) {
+            span.log("A span log");
+          }
+        };
 
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withClientSpanDecorator(spanTagger)
-        .withClientSpanDecorator(spanLogger)
-        .build();
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer)
+            .withClientSpanDecorator(spanTagger)
+            .withClientSpanDecorator(spanLogger)
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = clientTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
-    assertEquals("span should have one log from the decorator",
-        span.logEntries().get(0).fields().get("event"), "A span log");
-    Assertions.assertThat(span.tags()).as("span should have 3 tags from the decorator")
+    assertEquals(
+        "span should have one log from the decorator",
+        span.logEntries().get(0).fields().get("event"),
+        "A span log");
+    Assertions.assertThat(span.tags())
+        .as("span should have 3 tags from the decorator")
         .hasSize(3 + BASE_CLIENT_TAGS.size());
-    Assertions.assertThat(span.tags()).as("span contains added tags")
+    Assertions.assertThat(span.tags())
+        .as("span contains added tags")
         .containsEntry("test_tag", "test_value")
         .containsKeys("tag_from_method", "tag_from_call_options");
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedClientWithClientCloseDecorator() {
-    ClientCloseDecorator closeTagger = new ClientCloseDecorator() {
-      @Override
-      public void close(Span span, Status status, Metadata trailers) {
-        span.setTag("some_tag", "some_value");
-      }
-    };
-    ClientCloseDecorator closeLogger = new ClientCloseDecorator() {
-      @Override
-      public void close(Span span, Status status, Metadata trailers) {
-        span.log("A close log");
-      }
-    };
+    ClientCloseDecorator closeTagger =
+        new ClientCloseDecorator() {
+          @Override
+          public void close(Span span, Status status, Metadata trailers) {
+            span.setTag("some_tag", "some_value");
+          }
+        };
+    ClientCloseDecorator closeLogger =
+        new ClientCloseDecorator() {
+          @Override
+          public void close(Span span, Status status, Metadata trailers) {
+            span.log("A close log");
+          }
+        };
 
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(clientTracer)
-        .withClientCloseDecorator(closeTagger)
-        .withClientCloseDecorator(closeLogger)
-        .build();
+    TracingClientInterceptor tracingInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer)
+            .withClientCloseDecorator(closeTagger)
+            .withClientCloseDecorator(closeLogger)
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        clientTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
     MockSpan span = clientTracer.finishedSpans().get(0);
-    assertEquals("span should have one log from the decorator",
-        span.logEntries().get(0).fields().get("event"), "A close log");
-    Assertions.assertThat(span.tags())
-        .containsEntry("some_tag", "some_value");
+    assertEquals(
+        "span should have one log from the decorator",
+        span.logEntries().get(0).fields().get("event"),
+        "A close log");
+    Assertions.assertThat(span.tags()).containsEntry("some_tag", "some_value");
   }
 
   private Callable<Integer> reportedSpansSize(final MockTracer mockTracer) {

--- a/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
@@ -59,7 +59,7 @@ public class TracingInterceptorsTest {
   @Rule public GrpcServerRule grpcServer = new GrpcServerRule();
 
   @Before
-  public void before() {
+  public void setUp() {
     GlobalTracerTestUtil.resetGlobalTracer();
     clientTracer.reset();
     serverTracer.reset();
@@ -70,11 +70,17 @@ public class TracingInterceptorsTest {
   @Test
   public void testTracedClientAndServerSuccess() {
     TracingClientInterceptor clientInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withVerbosity()
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), clientInterceptor);
 
     TracingServerInterceptor serverInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
+            .withVerbosity()
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), serverInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -151,7 +157,10 @@ public class TracingInterceptorsTest {
   @Test
   public void testTracedClientSendError() {
     TracingClientInterceptor clientInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withVerbosity()
+            .build();
     ClientInterceptor clientSendError =
         new ClientInterceptor() {
           @Override
@@ -170,7 +179,10 @@ public class TracingInterceptorsTest {
         new TracedClient(grpcServer.getChannel(), clientSendError, clientInterceptor);
 
     TracingServerInterceptor serverInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
+            .withVerbosity()
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), serverInterceptor);
 
     assertNull("call should return null", client.greet());
@@ -223,7 +235,10 @@ public class TracingInterceptorsTest {
   @Test
   public void testTracedClientReceiveError() {
     TracingClientInterceptor clientInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withVerbosity()
+            .build();
     ClientInterceptor clientReceiveError =
         new ClientInterceptor() {
           @Override
@@ -251,7 +266,10 @@ public class TracingInterceptorsTest {
         new TracedClient(grpcServer.getChannel(), clientReceiveError, clientInterceptor);
 
     TracingServerInterceptor serverInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
+            .withVerbosity()
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), serverInterceptor);
 
     assertNull("call should return null", client.greet());
@@ -310,11 +328,17 @@ public class TracingInterceptorsTest {
   @Test
   public void testTracedServerReceiveError() {
     TracingClientInterceptor clientInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withVerbosity()
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), clientInterceptor);
 
     TracingServerInterceptor serverInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
+            .withVerbosity()
+            .build();
     ServerInterceptor serverReceiveError =
         new ServerInterceptor() {
           @Override
@@ -390,11 +414,17 @@ public class TracingInterceptorsTest {
   @Test
   public void testTracedServerSendError() {
     TracingClientInterceptor clientInterceptor =
-        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withVerbosity()
+            .build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), clientInterceptor);
 
     TracingServerInterceptor serverInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
+            .withVerbosity()
+            .build();
     ServerInterceptor serverSendError =
         new ServerInterceptor() {
           @Override

--- a/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingInterceptorsTest.java
@@ -56,8 +56,7 @@ public class TracingInterceptorsTest {
   private final MockTracer clientTracer = new MockTracer();
   private final MockTracer serverTracer = new MockTracer();
 
-  @Rule
-  public GrpcServerRule grpcServer = new GrpcServerRule();
+  @Rule public GrpcServerRule grpcServer = new GrpcServerRule();
 
   @Before
   public void before() {
@@ -70,23 +69,22 @@ public class TracingInterceptorsTest {
 
   @Test
   public void testTracedClientAndServerSuccess() {
-    TracingClientInterceptor clientInterceptor = new TracingClientInterceptor.Builder(clientTracer)
-        .withVerbosity()
-        .build();
+    TracingClientInterceptor clientInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), clientInterceptor);
 
-    TracingServerInterceptor serverInterceptor = new TracingServerInterceptor.Builder(serverTracer)
-        .withVerbosity()
-        .build();
+    TracingServerInterceptor serverInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), serverInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
 
-    assertEquals("a client span should have been created for the request",
-        1, clientTracer.finishedSpans().size());
+    assertEquals(
+        "a client span should have been created for the request",
+        1,
+        clientTracer.finishedSpans().size());
     MockSpan clientSpan = clientTracer.finishedSpans().get(0);
     List<String> clientEvents = new ArrayList<>(clientSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : clientSpan.logEntries()) {
@@ -107,8 +105,10 @@ public class TracingInterceptorsTest {
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.OK.name());
 
-    assertEquals("a server span should have been created for the request",
-        1, serverTracer.finishedSpans().size());
+    assertEquals(
+        "a server span should have been created for the request",
+        1,
+        serverTracer.finishedSpans().size());
     MockSpan serverSpan = serverTracer.finishedSpans().get(0);
     List<String> serverEvents = new ArrayList<>(serverSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : serverSpan.logEntries()) {
@@ -129,52 +129,58 @@ public class TracingInterceptorsTest {
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.OK.name());
 
-    assertEquals("client and server spans should be part of the same trace",
-        clientSpan.context().traceId(), serverSpan.context().traceId());
-    assertEquals("client span should be parent of server span",
-        clientSpan.context().spanId(), serverSpan.parentId());
-    assertEquals("server span should be child of client span",
-        References.CHILD_OF, serverSpan.references().get(0).getReferenceType());
+    assertEquals(
+        "client and server spans should be part of the same trace",
+        clientSpan.context().traceId(),
+        serverSpan.context().traceId());
+    assertEquals(
+        "client span should be parent of server span",
+        clientSpan.context().spanId(),
+        serverSpan.parentId());
+    assertEquals(
+        "server span should be child of client span",
+        References.CHILD_OF,
+        serverSpan.references().get(0).getReferenceType());
 
-    assertTrue("client span should be longer than the server span",
+    assertTrue(
+        "client span should be longer than the server span",
         (clientSpan.finishMicros() - clientSpan.startMicros())
             >= (serverSpan.finishMicros() - serverSpan.startMicros()));
   }
 
   @Test
   public void testTracedClientSendError() {
-    TracingClientInterceptor clientInterceptor = new TracingClientInterceptor.Builder(clientTracer)
-        .withVerbosity()
-        .build();
-    ClientInterceptor clientSendError = new ClientInterceptor() {
-      @Override
-      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-          MethodDescriptor<ReqT, RespT> method,
-          CallOptions callOptions,
-          Channel next) {
-        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
-            next.newCall(method, callOptions)) {
+    TracingClientInterceptor clientInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+    ClientInterceptor clientSendError =
+        new ClientInterceptor() {
           @Override
-          public void sendMessage(ReqT message) {
-            throw new RuntimeException("client send error");
+          public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+              MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                next.newCall(method, callOptions)) {
+              @Override
+              public void sendMessage(ReqT message) {
+                throw new RuntimeException("client send error");
+              }
+            };
           }
         };
-      }
-    };
-    TracedClient client = new TracedClient(grpcServer.getChannel(), clientSendError,
-        clientInterceptor);
+    TracedClient client =
+        new TracedClient(grpcServer.getChannel(), clientSendError, clientInterceptor);
 
-    TracingServerInterceptor serverInterceptor = new TracingServerInterceptor.Builder(serverTracer)
-        .withVerbosity()
-        .build();
+    TracingServerInterceptor serverInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), serverInterceptor);
 
     assertNull("call should return null", client.greet());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
 
-    assertEquals("a client span should have been created for the request",
-        1, clientTracer.finishedSpans().size());
+    assertEquals(
+        "a client span should have been created for the request",
+        1,
+        clientTracer.finishedSpans().size());
     MockSpan clientSpan = clientTracer.finishedSpans().get(0);
     List<String> clientEvents = new ArrayList<>(clientSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : clientSpan.logEntries()) {
@@ -187,7 +193,7 @@ public class TracingInterceptorsTest {
             GrpcFields.CLIENT_CALL_SEND_MESSAGE,
             GrpcFields.CLIENT_CALL_CANCEL,
             // TODO: onClose is not called due to bug: https://github.com/grpc/grpc-java/issues/5576
-            //GrpcFields.CLIENT_CALL_LISTENER_ON_CLOSE,
+            // GrpcFields.CLIENT_CALL_LISTENER_ON_CLOSE,
             GrpcFields.ERROR);
     Assertions.assertThat(clientSpan.tags())
         .as("client span grpc.status tag should equal UNKNOWN")
@@ -195,8 +201,10 @@ public class TracingInterceptorsTest {
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.UNKNOWN.name());
 
-    assertEquals("a server span should have been created for the request",
-        1, serverTracer.finishedSpans().size());
+    assertEquals(
+        "a server span should have been created for the request",
+        1,
+        serverTracer.finishedSpans().size());
     MockSpan serverSpan = serverTracer.finishedSpans().get(0);
     List<String> serverEvents = new ArrayList<>(serverSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : serverSpan.logEntries()) {
@@ -214,45 +222,46 @@ public class TracingInterceptorsTest {
 
   @Test
   public void testTracedClientReceiveError() {
-    TracingClientInterceptor clientInterceptor = new TracingClientInterceptor.Builder(clientTracer)
-        .withVerbosity()
-        .build();
-    ClientInterceptor clientReceiveError = new ClientInterceptor() {
-      @Override
-      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-          MethodDescriptor<ReqT, RespT> method,
-          CallOptions callOptions,
-          Channel next) {
-        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
-            next.newCall(method, callOptions)) {
+    TracingClientInterceptor clientInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
+    ClientInterceptor clientReceiveError =
+        new ClientInterceptor() {
           @Override
-          public void start(Listener<RespT> responseListener, Metadata headers) {
-            delegate().start(
-                new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
-                    responseListener) {
-                  @Override
-                  public void onMessage(RespT message) {
-                    throw new RuntimeException("client receive error");
-                  }
-                }, headers);
+          public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+              MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+            return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                next.newCall(method, callOptions)) {
+              @Override
+              public void start(Listener<RespT> responseListener, Metadata headers) {
+                delegate()
+                    .start(
+                        new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
+                            responseListener) {
+                          @Override
+                          public void onMessage(RespT message) {
+                            throw new RuntimeException("client receive error");
+                          }
+                        },
+                        headers);
+              }
+            };
           }
         };
-      }
-    };
-    TracedClient client = new TracedClient(grpcServer.getChannel(), clientReceiveError,
-        clientInterceptor);
+    TracedClient client =
+        new TracedClient(grpcServer.getChannel(), clientReceiveError, clientInterceptor);
 
-    TracingServerInterceptor serverInterceptor = new TracingServerInterceptor.Builder(serverTracer)
-        .withVerbosity()
-        .build();
+    TracingServerInterceptor serverInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), serverInterceptor);
 
     assertNull("call should return null", client.greet());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
 
-    assertEquals("a client span should have been created for the request",
-        1, clientTracer.finishedSpans().size());
+    assertEquals(
+        "a client span should have been created for the request",
+        1,
+        clientTracer.finishedSpans().size());
     MockSpan clientSpan = clientTracer.finishedSpans().get(0);
     List<String> clientEvents = new ArrayList<>(clientSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : clientSpan.logEntries()) {
@@ -273,8 +282,10 @@ public class TracingInterceptorsTest {
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.CANCELLED.name());
 
-    assertEquals("a server span should have been created for the request",
-        1, serverTracer.finishedSpans().size());
+    assertEquals(
+        "a server span should have been created for the request",
+        1,
+        serverTracer.finishedSpans().size());
     MockSpan serverSpan = serverTracer.finishedSpans().get(0);
     List<String> serverEvents = new ArrayList<>(serverSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : serverSpan.logEntries()) {
@@ -298,38 +309,37 @@ public class TracingInterceptorsTest {
 
   @Test
   public void testTracedServerReceiveError() {
-    TracingClientInterceptor clientInterceptor = new TracingClientInterceptor.Builder(clientTracer)
-        .withVerbosity()
-        .build();
+    TracingClientInterceptor clientInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), clientInterceptor);
 
-    TracingServerInterceptor serverInterceptor = new TracingServerInterceptor.Builder(serverTracer)
-        .withVerbosity()
-        .build();
-    ServerInterceptor serverReceiveError = new ServerInterceptor() {
-      @Override
-      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-          ServerCall<ReqT, RespT> call,
-          Metadata headers,
-          ServerCallHandler<ReqT, RespT> next) {
-        return new ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
-            next.startCall(call, headers)) {
+    TracingServerInterceptor serverInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+    ServerInterceptor serverReceiveError =
+        new ServerInterceptor() {
           @Override
-          public void onMessage(ReqT message) {
-            throw new RuntimeException("server receive error");
+          public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+              ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            return new ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(
+                next.startCall(call, headers)) {
+              @Override
+              public void onMessage(ReqT message) {
+                throw new RuntimeException("server receive error");
+              }
+            };
           }
         };
-      }
-    };
-    TracedService
-        .addGeeterService(grpcServer.getServiceRegistry(), serverReceiveError, serverInterceptor);
+    TracedService.addGeeterService(
+        grpcServer.getServiceRegistry(), serverReceiveError, serverInterceptor);
 
     assertNull("call should return null", client.greet());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
 
-    assertEquals("a client span should have been created for the request",
-        1, clientTracer.finishedSpans().size());
+    assertEquals(
+        "a client span should have been created for the request",
+        1,
+        clientTracer.finishedSpans().size());
     MockSpan clientSpan = clientTracer.finishedSpans().get(0);
     List<String> clientEvents = new ArrayList<>(clientSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : clientSpan.logEntries()) {
@@ -349,8 +359,10 @@ public class TracingInterceptorsTest {
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.UNKNOWN.name());
 
-    assertEquals("a server span should have been created for the request",
-        1, serverTracer.finishedSpans().size());
+    assertEquals(
+        "a server span should have been created for the request",
+        1,
+        serverTracer.finishedSpans().size());
     MockSpan serverSpan = serverTracer.finishedSpans().get(0);
     List<String> serverEvents = new ArrayList<>(serverSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : serverSpan.logEntries()) {
@@ -364,51 +376,51 @@ public class TracingInterceptorsTest {
         .as("server span should contain verbose log fields")
         .contains(
             GrpcFields.SERVER_CALL_LISTENER_ON_MESSAGE,
-            //GrpcFields.SERVER_CALL_LISTENER_ON_HALF_CLOSE,
-            //GrpcFields.SERVER_CALL_CLOSE,
-            //GrpcFields.ERROR,
+            // GrpcFields.SERVER_CALL_LISTENER_ON_HALF_CLOSE,
+            // GrpcFields.SERVER_CALL_CLOSE,
+            // GrpcFields.ERROR,
             GrpcFields.SERVER_CALL_LISTENER_ON_COMPLETE);
     Assertions.assertThat(serverSpan.tags())
         .as("server span grpc.status tag should equal INTERNAL")
         .containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME);
-    //.containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.INTERNAL.name());
+    // .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.INTERNAL.name());
   }
 
   @Test
   public void testTracedServerSendError() {
-    TracingClientInterceptor clientInterceptor = new TracingClientInterceptor.Builder(clientTracer)
-        .withVerbosity()
-        .build();
+    TracingClientInterceptor clientInterceptor =
+        new TracingClientInterceptor.Builder(clientTracer).withVerbosity().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), clientInterceptor);
 
-    TracingServerInterceptor serverInterceptor = new TracingServerInterceptor.Builder(serverTracer)
-        .withVerbosity()
-        .build();
-    ServerInterceptor serverSendError = new ServerInterceptor() {
-      @Override
-      public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-          ServerCall<ReqT, RespT> call,
-          Metadata headers,
-          ServerCallHandler<ReqT, RespT> next) {
-        return next
-            .startCall(new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
-              @Override
-              public void sendMessage(RespT message) {
-                throw new RuntimeException("server send error");
-              }
-            }, headers);
-      }
-    };
-    TracedService
-        .addGeeterService(grpcServer.getServiceRegistry(), serverSendError, serverInterceptor);
+    TracingServerInterceptor serverInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+    ServerInterceptor serverSendError =
+        new ServerInterceptor() {
+          @Override
+          public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+              ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+            return next.startCall(
+                new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+                  @Override
+                  public void sendMessage(RespT message) {
+                    throw new RuntimeException("server send error");
+                  }
+                },
+                headers);
+          }
+        };
+    TracedService.addGeeterService(
+        grpcServer.getServiceRegistry(), serverSendError, serverInterceptor);
 
     assertNull("call should return null", client.greet());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
 
-    assertEquals("a client span should have been created for the request",
-        1, clientTracer.finishedSpans().size());
+    assertEquals(
+        "a client span should have been created for the request",
+        1,
+        clientTracer.finishedSpans().size());
     MockSpan clientSpan = clientTracer.finishedSpans().get(0);
     List<String> clientEvents = new ArrayList<>(clientSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : clientSpan.logEntries()) {
@@ -429,8 +441,10 @@ public class TracingInterceptorsTest {
         .containsEntry(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
         .containsEntry(GrpcTags.GRPC_STATUS.getKey(), Status.Code.UNKNOWN.name());
 
-    assertEquals("a server span should have been created for the request",
-        1, serverTracer.finishedSpans().size());
+    assertEquals(
+        "a server span should have been created for the request",
+        1,
+        serverTracer.finishedSpans().size());
     MockSpan serverSpan = serverTracer.finishedSpans().get(0);
     List<String> serverEvents = new ArrayList<>(serverSpan.logEntries().size());
     for (MockSpan.LogEntry logEntry : serverSpan.logEntries()) {

--- a/src/test/java/io/opentracing/contrib/grpc/TracingServerInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingServerInterceptorTest.java
@@ -59,27 +59,29 @@ public class TracingServerInterceptorTest {
 
   private static final String PREFIX = "testing-";
 
-  private static final Map<String, Object> BASE_TAGS = ImmutableMap.<String, Object>builder()
-      .put(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
-      .put(GrpcTags.GRPC_STATUS.getKey(), Status.Code.OK.name())
-      .build();
+  private static final Map<String, Object> BASE_TAGS =
+      ImmutableMap.<String, Object>builder()
+          .put(Tags.COMPONENT.getKey(), GrpcTags.COMPONENT_NAME)
+          .put(GrpcTags.GRPC_STATUS.getKey(), Status.Code.OK.name())
+          .build();
 
-  private static final Map<String, Object> BASE_SERVER_TAGS = ImmutableMap.<String, Object>builder()
-      .putAll(BASE_TAGS)
-      .put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
-      .build();
+  private static final Map<String, Object> BASE_SERVER_TAGS =
+      ImmutableMap.<String, Object>builder()
+          .putAll(BASE_TAGS)
+          .put(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+          .build();
 
-  private static final Set<String> SERVER_ATTRIBUTE_TAGS = ImmutableSet.of(
-      GrpcTags.GRPC_METHOD_TYPE.getKey(),
-      GrpcTags.GRPC_METHOD_NAME.getKey(),
-      GrpcTags.GRPC_CALL_ATTRIBUTES.getKey(),
-      GrpcTags.GRPC_HEADERS.getKey(),
-      GrpcTags.PEER_ADDRESS.getKey());
+  private static final Set<String> SERVER_ATTRIBUTE_TAGS =
+      ImmutableSet.of(
+          GrpcTags.GRPC_METHOD_TYPE.getKey(),
+          GrpcTags.GRPC_METHOD_NAME.getKey(),
+          GrpcTags.GRPC_CALL_ATTRIBUTES.getKey(),
+          GrpcTags.GRPC_HEADERS.getKey(),
+          GrpcTags.PEER_ADDRESS.getKey());
 
   private final MockTracer serverTracer = new MockTracer();
 
-  @Rule
-  public GrpcServerRule grpcServer = new GrpcServerRule();
+  @Rule public GrpcServerRule grpcServer = new GrpcServerRule();
 
   private TracedClient client;
 
@@ -95,21 +97,22 @@ public class TracingServerInterceptorTest {
     TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor(serverTracer);
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
-    assertEquals("span should have default name", span.operationName(),
-        "helloworld.Greeter/SayHello");
+    assertEquals(
+        "span should have default name", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertTrue("span should have no logs", span.logEntries().isEmpty());
-    Assertions.assertThat(span.tags()).as("span should have base server tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base server tags")
         .isEqualTo(BASE_SERVER_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
@@ -119,40 +122,40 @@ public class TracingServerInterceptorTest {
     TracedService.addGeeterService(
         grpcServer.getServiceRegistry(), secondServerInterceptor, tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
-    assertEquals("span should have default name", span.operationName(),
-        "helloworld.Greeter/SayHello");
+    assertEquals(
+        "span should have default name", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertTrue("span should have no logs", span.logEntries().isEmpty());
-    Assertions.assertThat(span.tags()).as("span should have base server tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base server tags")
         .isEqualTo(BASE_SERVER_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedServerWithVerbosity() {
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(serverTracer)
-        .withVerbosity()
-        .build();
+    TracingServerInterceptor tracingInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
-    assertEquals("span should have default name", span.operationName(),
-        "helloworld.Greeter/SayHello");
+    assertEquals(
+        "span should have default name", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     List<String> events = new ArrayList<>(span.logEntries().size());
     for (MockSpan.LogEntry logEntry : span.logEntries()) {
@@ -167,29 +170,28 @@ public class TracingServerInterceptorTest {
             GrpcFields.SERVER_CALL_SEND_MESSAGE,
             GrpcFields.SERVER_CALL_CLOSE,
             GrpcFields.SERVER_CALL_LISTENER_ON_COMPLETE);
-    Assertions.assertThat(span.tags()).as("span should have base server tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base server tags")
         .isEqualTo(BASE_SERVER_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedServerWithStreaming() {
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(serverTracer)
-        .withStreaming()
-        .build();
+    TracingServerInterceptor tracingInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer).withStreaming().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
-    assertEquals("span should have default name", span.operationName(),
-        "helloworld.Greeter/SayHello");
+    assertEquals(
+        "span should have default name", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     List<String> events = new ArrayList<>(span.logEntries().size());
     for (MockSpan.LogEntry logEntry : span.logEntries()) {
@@ -201,145 +203,159 @@ public class TracingServerInterceptorTest {
             GrpcFields.SERVER_CALL_LISTENER_ON_MESSAGE,
             GrpcFields.SERVER_CALL_LISTENER_ON_HALF_CLOSE,
             GrpcFields.SERVER_CALL_SEND_MESSAGE);
-    Assertions.assertThat(span.tags()).as("span should have base server tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base server tags")
         .isEqualTo(BASE_SERVER_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedServerWithCustomOperationName() {
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(serverTracer)
-        .withOperationName(new OperationNameConstructor() {
-          @Override
-          public <ReqT, RespT> String constructOperationName(MethodDescriptor<ReqT, RespT> method) {
-            return PREFIX + method.getFullMethodName();
-          }
-        })
-        .build();
+    TracingServerInterceptor tracingInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer)
+            .withOperationName(
+                new OperationNameConstructor() {
+                  @Override
+                  public <ReqT, RespT> String constructOperationName(
+                      MethodDescriptor<ReqT, RespT> method) {
+                    return PREFIX + method.getFullMethodName();
+                  }
+                })
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
-    assertEquals("span should have prefix", span.operationName(),
-        PREFIX + "helloworld.Greeter/SayHello");
+    assertEquals(
+        "span should have prefix", span.operationName(), PREFIX + "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base server tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base server tags")
         .isEqualTo(BASE_SERVER_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedServerWithTracedAttributes() {
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(serverTracer)
-        .withTracedAttributes(TracingServerInterceptor.ServerRequestAttribute.values())
-        .build();
+    TracingServerInterceptor tracingInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer)
+            .withTracedAttributes(TracingServerInterceptor.ServerRequestAttribute.values())
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
-    Assertions.assertThat(span.tags()).as("span should have base server tags")
+    Assertions.assertThat(span.tags())
+        .as("span should have base server tags")
         .containsAllEntriesOf(BASE_SERVER_TAGS);
     Assertions.assertThat(span.tags().keySet())
         .as("span should have tags for all server request attributes")
         .containsAll(SERVER_ATTRIBUTE_TAGS);
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedServerWithServerSpanDecorator() {
-    ServerSpanDecorator spanTagger = new ServerSpanDecorator() {
-      @Override
-      public void interceptCall(Span span, ServerCall call, Metadata headers) {
-        span.setTag("test_tag", "test_value");
-        span.setTag("tag_from_call", call.getAuthority());
-        span.setTag("tag_from_headers", headers.toString());
-      }
-    };
-    ServerSpanDecorator spanLogger = new ServerSpanDecorator() {
-      @Override
-      public void interceptCall(Span span, ServerCall call, Metadata headers) {
-        span.log("A span log");
-      }
-    };
+    ServerSpanDecorator spanTagger =
+        new ServerSpanDecorator() {
+          @Override
+          public void interceptCall(Span span, ServerCall call, Metadata headers) {
+            span.setTag("test_tag", "test_value");
+            span.setTag("tag_from_call", call.getAuthority());
+            span.setTag("tag_from_headers", headers.toString());
+          }
+        };
+    ServerSpanDecorator spanLogger =
+        new ServerSpanDecorator() {
+          @Override
+          public void interceptCall(Span span, ServerCall call, Metadata headers) {
+            span.log("A span log");
+          }
+        };
 
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(serverTracer)
-        .withServerSpanDecorator(spanTagger)
-        .withServerSpanDecorator(spanLogger)
-        .build();
+    TracingServerInterceptor tracingInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer)
+            .withServerSpanDecorator(spanTagger)
+            .withServerSpanDecorator(spanLogger)
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
     assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
     assertEquals("span should have no parents", span.parentId(), 0);
-    assertEquals("span should have one log added in the decorator",
-        span.logEntries().get(0).fields().get("event"), "A span log");
-    Assertions.assertThat(span.tags()).as("span should have 3 tags added in the decorator")
+    assertEquals(
+        "span should have one log added in the decorator",
+        span.logEntries().get(0).fields().get("event"),
+        "A span log");
+    Assertions.assertThat(span.tags())
+        .as("span should have 3 tags added in the decorator")
         .hasSize(3 + BASE_SERVER_TAGS.size());
-    Assertions.assertThat(span.tags()).as("span contains added tags")
+    Assertions.assertThat(span.tags())
+        .as("span contains added tags")
         .containsEntry("test_tag", "test_value")
         .containsKeys("tag_from_call", "tag_from_headers");
-    assertFalse("span should have no baggage",
-        span.context().baggageItems().iterator().hasNext());
+    assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
   }
 
   @Test
   public void testTracedServerWithServerCloseDecorator() {
-    ServerCloseDecorator closeTagger = new ServerCloseDecorator() {
-      @Override
-      public void close(Span span, Status status, Metadata trailers) {
-        span.setTag("some_tag", "some_value");
-      }
-    };
-    ServerCloseDecorator closeLogger = new ServerCloseDecorator() {
-      @Override
-      public void close(Span span, Status status, Metadata trailers) {
-        span.log("A close log");
-      }
-    };
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(serverTracer)
-        .withServerCloseDecorator(closeTagger)
-        .withServerCloseDecorator(closeLogger)
-        .build();
+    ServerCloseDecorator closeTagger =
+        new ServerCloseDecorator() {
+          @Override
+          public void close(Span span, Status status, Metadata trailers) {
+            span.setTag("some_tag", "some_value");
+          }
+        };
+    ServerCloseDecorator closeLogger =
+        new ServerCloseDecorator() {
+          @Override
+          public void close(Span span, Status status, Metadata trailers) {
+            span.log("A close log");
+          }
+        };
+    TracingServerInterceptor tracingInterceptor =
+        new TracingServerInterceptor.Builder(serverTracer)
+            .withServerCloseDecorator(closeTagger)
+            .withServerCloseDecorator(closeLogger)
+            .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
-    assertEquals("call should complete successfully", "Hello world",
-        client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
-    assertEquals("one span should have been created and finished for one client request",
-        serverTracer.finishedSpans().size(), 1);
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        serverTracer.finishedSpans().size(),
+        1);
 
     MockSpan span = serverTracer.finishedSpans().get(0);
-    assertEquals("span should have one log from the decorator",
-        span.logEntries().get(0).fields().get("event"), "A close log");
-    Assertions.assertThat(span.tags())
-        .containsEntry("some_tag", "some_value");
+    assertEquals(
+        "span should have one log from the decorator",
+        span.logEntries().get(0).fields().get("event"),
+        "A close log");
+    Assertions.assertThat(span.tags()).containsEntry("some_tag", "some_value");
   }
 
   @Test
@@ -351,12 +367,13 @@ public class TracingServerInterceptorTest {
         .when(spyTracer)
         .extract(eq(Format.Builtin.HTTP_HEADERS), any(TextMapAdapter.class));
 
-    Span span = new TracingServerInterceptor(spyTracer).getSpanFromHeaders(
-        Collections.<String, String>emptyMap(), "operationName");
+    Span span =
+        new TracingServerInterceptor(spyTracer)
+            .getSpanFromHeaders(Collections.<String, String>emptyMap(), "operationName");
     assertNotNull("span is not null", span);
     MockSpan mockSpan = (MockSpan) span;
-    assertEquals("span parentID is set to extracted span context spanID",
-        spanID, mockSpan.parentId());
+    assertEquals(
+        "span parentID is set to extracted span context spanID", spanID, mockSpan.parentId());
     List<MockSpan.LogEntry> logEntries = mockSpan.logEntries();
     assertTrue("span contains no log entries", logEntries.isEmpty());
   }
@@ -368,15 +385,20 @@ public class TracingServerInterceptorTest {
         .when(spyTracer)
         .extract(eq(Format.Builtin.HTTP_HEADERS), any(TextMapAdapter.class));
 
-    Span span = new TracingServerInterceptor(spyTracer).getSpanFromHeaders(
-        Collections.<String, String>emptyMap(), "operationName");
+    Span span =
+        new TracingServerInterceptor(spyTracer)
+            .getSpanFromHeaders(Collections.<String, String>emptyMap(), "operationName");
     assertNotNull("span is not null", span);
     List<MockSpan.LogEntry> logEntries = ((MockSpan) span).logEntries();
     assertEquals("span contains 1 log entry", 1, logEntries.size());
-    assertEquals("span log contains error field", GrpcFields.ERROR,
+    assertEquals(
+        "span log contains error field",
+        GrpcFields.ERROR,
         logEntries.get(0).fields().get(Fields.EVENT));
-    assertThat("span log contains error.object field",
-        logEntries.get(0).fields().get(Fields.ERROR_OBJECT), instanceOf(RuntimeException.class));
+    assertThat(
+        "span log contains error.object field",
+        logEntries.get(0).fields().get(Fields.ERROR_OBJECT),
+        instanceOf(RuntimeException.class));
   }
 
   private Callable<Integer> reportedSpansSize(final MockTracer mockTracer) {

--- a/src/test/java/io/opentracing/contrib/grpc/TracingServerInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingServerInterceptorTest.java
@@ -86,7 +86,7 @@ public class TracingServerInterceptorTest {
   private TracedClient client;
 
   @Before
-  public void before() {
+  public void setUp() {
     GlobalTracerTestUtil.resetGlobalTracer();
     serverTracer.reset();
     client = new TracedClient(grpcServer.getChannel());
@@ -94,7 +94,8 @@ public class TracingServerInterceptorTest {
 
   @Test
   public void testTracedServerBasic() {
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor(serverTracer);
+    TracingServerInterceptor tracingInterceptor =
+        TracingServerInterceptor.newBuilder().withTracer(serverTracer).build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -117,7 +118,8 @@ public class TracingServerInterceptorTest {
 
   @Test
   public void testTracedServerTwoInterceptors() {
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor(serverTracer);
+    TracingServerInterceptor tracingInterceptor =
+        TracingServerInterceptor.newBuilder().withTracer(serverTracer).build();
     SecondServerInterceptor secondServerInterceptor = new SecondServerInterceptor(serverTracer);
     TracedService.addGeeterService(
         grpcServer.getServiceRegistry(), secondServerInterceptor, tracingInterceptor);
@@ -143,7 +145,7 @@ public class TracingServerInterceptorTest {
   @Test
   public void testTracedServerWithVerbosity() {
     TracingServerInterceptor tracingInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withVerbosity().build();
+        TracingServerInterceptor.newBuilder().withTracer(serverTracer).withVerbosity().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -179,7 +181,7 @@ public class TracingServerInterceptorTest {
   @Test
   public void testTracedServerWithStreaming() {
     TracingServerInterceptor tracingInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer).withStreaming().build();
+        TracingServerInterceptor.newBuilder().withTracer(serverTracer).withStreaming().build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
@@ -212,7 +214,8 @@ public class TracingServerInterceptorTest {
   @Test
   public void testTracedServerWithCustomOperationName() {
     TracingServerInterceptor tracingInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer)
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
             .withOperationName(
                 new OperationNameConstructor() {
                   @Override
@@ -245,7 +248,8 @@ public class TracingServerInterceptorTest {
   @Test
   public void testTracedServerWithTracedAttributes() {
     TracingServerInterceptor tracingInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer)
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
             .withTracedAttributes(TracingServerInterceptor.ServerRequestAttribute.values())
             .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
@@ -290,7 +294,8 @@ public class TracingServerInterceptorTest {
         };
 
     TracingServerInterceptor tracingInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer)
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
             .withServerSpanDecorator(spanTagger)
             .withServerSpanDecorator(spanLogger)
             .build();
@@ -337,7 +342,8 @@ public class TracingServerInterceptorTest {
           }
         };
     TracingServerInterceptor tracingInterceptor =
-        new TracingServerInterceptor.Builder(serverTracer)
+        TracingServerInterceptor.newBuilder()
+            .withTracer(serverTracer)
             .withServerCloseDecorator(closeTagger)
             .withServerCloseDecorator(closeLogger)
             .build();
@@ -368,7 +374,9 @@ public class TracingServerInterceptorTest {
         .extract(eq(Format.Builtin.HTTP_HEADERS), any(TextMapAdapter.class));
 
     Span span =
-        new TracingServerInterceptor(spyTracer)
+        TracingServerInterceptor.newBuilder()
+            .withTracer(spyTracer)
+            .build()
             .getSpanFromHeaders(Collections.<String, String>emptyMap(), "operationName");
     assertNotNull("span is not null", span);
     MockSpan mockSpan = (MockSpan) span;
@@ -386,7 +394,9 @@ public class TracingServerInterceptorTest {
         .extract(eq(Format.Builtin.HTTP_HEADERS), any(TextMapAdapter.class));
 
     Span span =
-        new TracingServerInterceptor(spyTracer)
+        TracingServerInterceptor.newBuilder()
+            .withTracer(spyTracer)
+            .build()
             .getSpanFromHeaders(Collections.<String, String>emptyMap(), "operationName");
     assertNotNull("span is not null", span);
     List<MockSpan.LogEntry> logEntries = ((MockSpan) span).logEntries();


### PR DESCRIPTION
- Applied google-java-format IntelliJ plugin.
- Only use builders to construct interceptors.
- Default span context source to OpenTracing API `tracer.activeSpan().context()`.