### PR TITLE
Making TracingClientInterceptor.Builder constructor private

### DIFF
--- a/src/main/java/io/opentracing/contrib/grpc/TracingClientInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/TracingClientInterceptor.java
@@ -332,7 +332,7 @@ public class TracingClientInterceptor implements ClientInterceptor {
     private Map<Class<?>, ClientCloseDecorator> clientCloseDecorators;
 
     /** Creates a Builder with GlobalTracer if present else NoopTracer. */
-    public Builder() {
+    private Builder() {
       this.tracer = GlobalTracer.isRegistered() ? GlobalTracer.get() : NoopTracerFactory.create();
       this.operationNameConstructor = OperationNameConstructor.DEFAULT;
       this.streaming = false;

--- a/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
@@ -133,7 +133,7 @@ public class TracingClientInterceptorTest {
   @Test
   public void testTracedClientWithVerbosity() {
     TracingClientInterceptor tracingInterceptor =
-        new TracingClientInterceptor.Builder().withTracer(clientTracer).withVerbosity().build();
+        TracingClientInterceptor.newBuilder().withTracer(clientTracer).withVerbosity().build();
     TracedClient client = new TracedClient(grpcServer.getChannel(), tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());


### PR DESCRIPTION
- Builder constructor is private and should be accessed via the static `TracingClientInterceptor.newBuilder()` method.
- Same as `TracingServerInterceptor.newBuilder()`.