### PR TITLE
Set scope=provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
       <version>${grpc.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target library to "provided". It is a guarantee that the integrating codebase will provide this library, otherwise the instrumentation plugin would be moot if the codebase does not already have this library.