### PR TITLE
Fix readme - builder usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import io.opentracing.Tracer;
 
         private void start() throws IOException {
             TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-                .Builder()
+                .newBuilder()
                 .withTracer(this.tracer)
                 .build();
             
@@ -72,7 +72,7 @@ import io.opentracing.Tracer;import io.opentracing.contrib.grpc.TracingClientInt
                 .build();
 
             TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-                .Builder()
+                .newBuilder()
                 .withTracer(this.tracer)
                 .build();
             
@@ -129,7 +129,7 @@ A `TracingClientInterceptor` also has default settings, which you can override b
 import io.opentracing.Span;
 
     TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder()
+        .newBuilder()
         .withTracer(tracer)
         .withStreaming()
         .withVerbosity()
@@ -231,7 +231,7 @@ For example, if you're creating the client in an environment that has the active
 import io.opentracing.Span;
 
     TracingClientInterceptor interceptor = new TracingClientInterceptor
-        .Builder().withTracer(tracer)
+        .newBuilder().withTracer(tracer)
         ...
         .withActiveSpanSource(new ActiveSpanSource() {
             @Override
@@ -256,7 +256,7 @@ Instead of `ActiveSpanSource` it's possible to use `ActiveSpanContextSource` if 
 import io.opentracing.Span;
 
     TracingClientInterceptor interceptor = new TracingClientInterceptor
-        .Builder().withTracer(tracer)
+        .newBuilder().withTracer(tracer)
         ...
         .withActiveSpanContextSource(new ActiveSpanContextSource() {
             @Override
@@ -281,7 +281,7 @@ Multiple different decorators may be added to the builder.
 
 ```java
 TracingClientInterceptor clientInterceptor = new TracingClientInterceptor
-    .Builder().withTracer(tracer)
+    .newBuilder().withTracer(tracer)
     ...
     .withClientSpanDecorator(new ClientSpanDecorator() {
         @Override
@@ -300,7 +300,7 @@ TracingClientInterceptor clientInterceptor = new TracingClientInterceptor
     .build();
     
 TracingServerInterceptor serverInterceptor = new TracingServerInterceptor
-    .Builder().withTracer(tracer)
+    .newBuilder().withTracer(tracer)
     ...
     .withServerSpanDecorator(new ServerSpanDecorator() {
         @Override
@@ -346,5 +346,4 @@ blockingStub = GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel,
 [cov-img]: https://coveralls.io/repos/github/opentracing-contrib/java-grpc/badge.svg?branch=master
 [cov]: https://coveralls.io/github/opentracing-contrib/java-grpc?branch=master
 [maven-img]: https://img.shields.io/maven-central/v/io.opentracing.contrib/opentracing-grpc.svg
-[maven]: http://search.maven.org/#search%7Cga%7C1%7Copentracing-grpc        
-        
+[maven]: http://search.maven.org/#search%7Cga%7C1%7Copentracing-grpc

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ A `TracingServerInterceptor` uses default settings, which you can override by cr
 
 ```java
     TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder
+        .newBuilder()
         .withTracer(tracer)
         .withStreaming()
         .withVerbosity()
@@ -347,3 +347,4 @@ blockingStub = GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel,
 [cov]: https://coveralls.io/github/opentracing-contrib/java-grpc?branch=master
 [maven-img]: https://img.shields.io/maven-central/v/io.opentracing.contrib/opentracing-grpc.svg
 [maven]: http://search.maven.org/#search%7Cga%7C1%7Copentracing-grpc
+

--- a/README.md
+++ b/README.md
@@ -347,4 +347,3 @@ blockingStub = GreeterGrpc.newBlockingStub(ClientInterceptors.intercept(channel,
 [cov]: https://coveralls.io/github/opentracing-contrib/java-grpc?branch=master
 [maven-img]: https://img.shields.io/maven-central/v/io.opentracing.contrib/opentracing-grpc.svg
 [maven]: http://search.maven.org/#search%7Cga%7C1%7Copentracing-grpc
-

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ import io.opentracing.Tracer;
 
         private void start() throws IOException {
             TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-                .Builder(this.tracer)
+                .Builder()
+                .withTracer(this.tracer)
                 .build();
             
             // If GlobalTracer is used: 
@@ -71,7 +72,8 @@ import io.opentracing.Tracer;import io.opentracing.contrib.grpc.TracingClientInt
                 .build();
 
             TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-                .Builder(this.tracer)
+                .Builder()
+                .withTracer(this.tracer)
                 .build();
             
             // If GlobalTracer is used: 
@@ -96,7 +98,8 @@ A `TracingServerInterceptor` uses default settings, which you can override by cr
 
 ```java
     TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
-        .Builder(tracer)
+        .Builder
+        .withTracer(tracer)
         .withStreaming()
         .withVerbosity()
         .withOperationName(new OperationNameConstructor() {
@@ -126,7 +129,8 @@ A `TracingClientInterceptor` also has default settings, which you can override b
 import io.opentracing.Span;
 
     TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
-        .Builder(tracer)
+        .Builder()
+        .withTracer(tracer)
         .withStreaming()
         .withVerbosity()
         .withOperationName(new OperationNameConstructor() {
@@ -227,7 +231,7 @@ For example, if you're creating the client in an environment that has the active
 import io.opentracing.Span;
 
     TracingClientInterceptor interceptor = new TracingClientInterceptor
-        .Builder(tracer)
+        .Builder().withTracer(tracer)
         ...
         .withActiveSpanSource(new ActiveSpanSource() {
             @Override
@@ -252,7 +256,7 @@ Instead of `ActiveSpanSource` it's possible to use `ActiveSpanContextSource` if 
 import io.opentracing.Span;
 
     TracingClientInterceptor interceptor = new TracingClientInterceptor
-        .Builder(tracer)
+        .Builder().withTracer(tracer)
         ...
         .withActiveSpanContextSource(new ActiveSpanContextSource() {
             @Override
@@ -277,7 +281,7 @@ Multiple different decorators may be added to the builder.
 
 ```java
 TracingClientInterceptor clientInterceptor = new TracingClientInterceptor
-    .Builder(tracer)
+    .Builder().withTracer(tracer)
     ...
     .withClientSpanDecorator(new ClientSpanDecorator() {
         @Override
@@ -296,7 +300,7 @@ TracingClientInterceptor clientInterceptor = new TracingClientInterceptor
     .build();
     
 TracingServerInterceptor serverInterceptor = new TracingServerInterceptor
-    .Builder(tracer)
+    .Builder().withTracer(tracer)
     ...
     .withServerSpanDecorator(new ServerSpanDecorator() {
         @Override

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import io.opentracing.Tracer;
         private final Tracer tracer;
 
         private void start() throws IOException {
-            TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
+            TracingServerInterceptor tracingInterceptor = TracingServerInterceptor
                 .newBuilder()
                 .withTracer(this.tracer)
                 .build();
@@ -71,7 +71,7 @@ import io.opentracing.Tracer;import io.opentracing.contrib.grpc.TracingClientInt
                 .usePlaintext(true)
                 .build();
 
-            TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
+            TracingClientInterceptor tracingInterceptor = TracingClientInterceptor
                 .newBuilder()
                 .withTracer(this.tracer)
                 .build();
@@ -97,7 +97,7 @@ A `TracingServerInterceptor` uses default settings, which you can override by cr
 ### Example
 
 ```java
-    TracingServerInterceptor tracingInterceptor = new TracingServerInterceptor
+    TracingServerInterceptor tracingInterceptor = TracingServerInterceptor
         .newBuilder()
         .withTracer(tracer)
         .withStreaming()
@@ -128,7 +128,7 @@ A `TracingClientInterceptor` also has default settings, which you can override b
 ```java
 import io.opentracing.Span;
 
-    TracingClientInterceptor tracingInterceptor = new TracingClientInterceptor
+    TracingClientInterceptor tracingInterceptor = TracingClientInterceptor
         .newBuilder()
         .withTracer(tracer)
         .withStreaming()
@@ -230,7 +230,7 @@ For example, if you're creating the client in an environment that has the active
 ```java
 import io.opentracing.Span;
 
-    TracingClientInterceptor interceptor = new TracingClientInterceptor
+    TracingClientInterceptor interceptor = TracingClientInterceptor
         .newBuilder().withTracer(tracer)
         ...
         .withActiveSpanSource(new ActiveSpanSource() {
@@ -255,7 +255,7 @@ Instead of `ActiveSpanSource` it's possible to use `ActiveSpanContextSource` if 
 ```java
 import io.opentracing.Span;
 
-    TracingClientInterceptor interceptor = new TracingClientInterceptor
+    TracingClientInterceptor interceptor = TracingClientInterceptor
         .newBuilder().withTracer(tracer)
         ...
         .withActiveSpanContextSource(new ActiveSpanContextSource() {
@@ -280,7 +280,7 @@ If you want to add custom tags or logs to the server and client spans, then you 
 Multiple different decorators may be added to the builder.
 
 ```java
-TracingClientInterceptor clientInterceptor = new TracingClientInterceptor
+TracingClientInterceptor clientInterceptor = TracingClientInterceptor
     .newBuilder().withTracer(tracer)
     ...
     .withClientSpanDecorator(new ClientSpanDecorator() {
@@ -299,7 +299,7 @@ TracingClientInterceptor clientInterceptor = new TracingClientInterceptor
     ...
     .build();
     
-TracingServerInterceptor serverInterceptor = new TracingServerInterceptor
+TracingServerInterceptor serverInterceptor = TracingServerInterceptor
     .newBuilder().withTracer(tracer)
     ...
     .withServerSpanDecorator(new ServerSpanDecorator() {


### PR DESCRIPTION
Current `Builder` constructor is [private](https://github.com/opentracing-contrib/java-grpc/blob/master/src/main/java/io/opentracing/contrib/grpc/TracingServerInterceptor.java#L74) and doesn't take `Tracer` as parameter anymore.

Switch to `newBuilder().withTracer(..)` instead