### PR TITLE
Add scope to intercept response message, from client & server side

### DIFF
--- a/src/main/java/io/opentracing/contrib/grpc/TracingClientInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/TracingClientInterceptor.java
@@ -196,7 +196,10 @@ public class TracingClientInterceptor implements ClientInterceptor {
                             .put(Fields.MESSAGE, "Client received response message")
                             .build());
                   }
-                  super.onMessage(message);
+
+                  try (Scope ignored = tracer.scopeManager().activate(span)) {
+                    super.onMessage(message);
+                  }
                 }
 
                 @Override

--- a/src/main/java/io/opentracing/contrib/grpc/TracingServerInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/TracingServerInterceptor.java
@@ -168,7 +168,10 @@ public class TracingServerInterceptor implements ServerInterceptor {
                         .put(Fields.MESSAGE, "Server sent response message")
                         .build());
               }
-              super.sendMessage(message);
+
+              try (Scope ignored = tracer.scopeManager().activate(span)) {
+                super.sendMessage(message);
+              }
             }
 
             @Override
@@ -187,6 +190,7 @@ public class TracingServerInterceptor implements ServerInterceptor {
               for (ServerCloseDecorator serverCloseDecorator : serverCloseDecorators) {
                 serverCloseDecorator.close(span, status, trailers);
               }
+
               super.close(status, trailers);
             }
           };

--- a/src/main/java/io/opentracing/contrib/grpc/TracingServerInterceptor.java
+++ b/src/main/java/io/opentracing/contrib/grpc/TracingServerInterceptor.java
@@ -190,7 +190,6 @@ public class TracingServerInterceptor implements ServerInterceptor {
               for (ServerCloseDecorator serverCloseDecorator : serverCloseDecorators) {
                 serverCloseDecorator.close(span, status, trailers);
               }
-
               super.close(status, trailers);
             }
           };


### PR DESCRIPTION
I'm trying to use `Client` & `Server` interceptor together with my custom interceptors, and I want to use the span scope inside `sendMessage` / `onMessage` (during sending response back)

I didn't include scope in the places where you already have an access to the span (say, metadata headers you can override in `serverSpanDecorator`,  close in `serverCloseDecorator`.

Moreover, the scope is already exposed in `onMessage` (when you receive a request), so it will be 
symmetrically consistent to have it for `sendMessage`.