### PR TITLE
Optionally include/exclude grpc headers by name

### DIFF
--- a/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracedClient.java
@@ -17,9 +17,13 @@ package io.opentracing.contrib.grpc;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
 import io.opentracing.contrib.grpc.gen.GreeterGrpc;
+import io.opentracing.contrib.grpc.gen.GreeterGrpc.GreeterBlockingStub;
 import io.opentracing.contrib.grpc.gen.HelloReply;
 import io.opentracing.contrib.grpc.gen.HelloRequest;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 class TracedClient {
@@ -47,5 +51,18 @@ class TracedClient {
     } catch (Exception ignored) {
       return null;
     }
+  }
+  
+  HelloReply greetWithHeaders(Map<String, String> headers) {
+      try {
+          Metadata metadata = new Metadata();
+          for(Map.Entry<String, String> entry : headers.entrySet()) {
+              metadata.put(Metadata.Key.of(entry.getKey(), Metadata.ASCII_STRING_MARSHALLER), entry.getValue());
+          }
+          GreeterBlockingStub stub = MetadataUtils.attachHeaders(blockingStub, metadata);
+          return stub.sayHello(HelloRequest.newBuilder().setName("world").build());
+      } catch(Exception ignored) {
+          return null;
+      }
   }
 }

--- a/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingClientInterceptorTest.java
@@ -34,6 +34,7 @@ import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracerTestUtil;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -240,7 +241,7 @@ public class TracingClientInterceptorTest {
             .withTracer(clientTracer)
             .withTracedAttributes(TracingClientInterceptor.ClientRequestAttribute.values())
             .build();
-    TracedClient client = new TracedClient(grpcServer.getChannel(), 50, "gzip", tracingInterceptor);
+    TracedClient client = new TracedClient(grpcServer.getChannel(), 5000, "gzip", tracingInterceptor);
 
     assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
@@ -260,6 +261,80 @@ public class TracingClientInterceptorTest {
         .as("span should have tags for all client request attributes")
         .containsAll(CLIENT_ATTRIBUTE_TAGS);
     assertFalse("span should have no baggage", span.context().baggageItems().iterator().hasNext());
+  }
+  
+  @Test
+  public void testTracedClientWithExcludedHeader() {
+    TracingClientInterceptor tracingInterceptor =
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withTracedAttributes(TracingClientInterceptor.ClientRequestAttribute.HEADERS)
+            .withExcludedHeaders(Metadata.Key.of("header2", Metadata.ASCII_STRING_MARSHALLER))
+            .build();
+    TracedClient client = new TracedClient(grpcServer.getChannel(), 5000, "gzip", tracingInterceptor);
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("header1", "value1");
+    headers.put("header2", "value2");
+    
+    assertEquals("call should complete successfully", "Hello world", client.greetWithHeaders(headers).getMessage());
+    await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
+
+    MockSpan span = clientTracer.finishedSpans().get(0);
+    assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
+    assertEquals("span should have no parents", span.parentId(), 0);
+    assertEquals("span should have no logs", span.logEntries().size(), 0);
+    Assertions.assertThat(span.tags())
+      .as("span should have base server tags")
+      .containsKey(GrpcTags.GRPC_HEADERS.getKey());
+    String headerString = (String) span.tags().get(GrpcTags.GRPC_HEADERS.getKey());
+    Assertions.assertThat(headerString)
+      .as("headers should have header1")
+      .contains("header1");
+    Assertions.assertThat(headerString)
+      .as("headers should NOT have header2")
+      .doesNotContain("header2");
+  }
+  
+  @Test
+  public void testTracedClientWithIncludedHeader() {
+    TracingClientInterceptor tracingInterceptor =
+        TracingClientInterceptor.newBuilder()
+            .withTracer(clientTracer)
+            .withTracedAttributes(TracingClientInterceptor.ClientRequestAttribute.HEADERS)
+            .withIncludedHeaders(Metadata.Key.of("header2", Metadata.ASCII_STRING_MARSHALLER))
+            .build();
+    TracedClient client = new TracedClient(grpcServer.getChannel(), 5000, "gzip", tracingInterceptor);
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put("header1", "value1");
+    headers.put("header2", "value2");
+    
+    assertEquals("call should complete successfully", "Hello world", client.greetWithHeaders(headers).getMessage());
+    await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(clientTracer), equalTo(1));
+    assertEquals(
+        "one span should have been created and finished for one client request",
+        clientTracer.finishedSpans().size(),
+        1);
+
+    MockSpan span = clientTracer.finishedSpans().get(0);
+    assertEquals("span should have prefix", span.operationName(), "helloworld.Greeter/SayHello");
+    assertEquals("span should have no parents", span.parentId(), 0);
+    assertEquals("span should have no logs", span.logEntries().size(), 0);
+    Assertions.assertThat(span.tags())
+      .as("span should have base server tags")
+      .containsKey(GrpcTags.GRPC_HEADERS.getKey());
+    String headerString = (String) span.tags().get(GrpcTags.GRPC_HEADERS.getKey());
+    Assertions.assertThat(headerString)
+      .as("headers should NOT have header1")
+      .doesNotContain("header1");
+    Assertions.assertThat(headerString)
+      .as("headers should have header2")
+      .contains("header2");
   }
 
   @Test

--- a/src/test/java/io/opentracing/contrib/grpc/TracingServerInterceptorTest.java
+++ b/src/test/java/io/opentracing/contrib/grpc/TracingServerInterceptorTest.java
@@ -46,6 +46,7 @@ import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracerTestUtil;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -278,16 +279,19 @@ public class TracingServerInterceptorTest {
   
   @Test
   public void testTracedServerWithExcludedHeader() {
-    Key<String> headerKey = Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER);
     TracingServerInterceptor tracingInterceptor =
         TracingServerInterceptor.newBuilder()
             .withTracer(serverTracer)
             .withTracedAttributes(TracingServerInterceptor.ServerRequestAttribute.HEADERS)
-            .withExcludedHeaders(headerKey)
+            .withExcludedHeaders(Metadata.Key.of("header2", Metadata.ASCII_STRING_MARSHALLER))
             .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
+    
+    Map<String, String> headers = new HashMap<>();
+    headers.put("header1", "value1");
+    headers.put("header2", "value2");
 
-    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greetWithHeaders(headers).getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
     assertEquals(
         "one span should have been created and finished for one client request",
@@ -299,26 +303,32 @@ public class TracingServerInterceptorTest {
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
     Assertions.assertThat(span.tags())
-        .as("span should have base server tags")
-        .containsKey(GrpcTags.GRPC_HEADERS.getKey());
-    String headers = (String) span.tags().get(GrpcTags.GRPC_HEADERS.getKey());
-    Assertions.assertThat(headers)
-        .as("headers should have user agent")
-        .doesNotContain("user-agent");
+      .as("span should have base server tags")
+      .containsKey(GrpcTags.GRPC_HEADERS.getKey());
+    String headerString = (String) span.tags().get(GrpcTags.GRPC_HEADERS.getKey());
+    Assertions.assertThat(headerString)
+      .as("headers should have header1")
+      .contains("header1");
+    Assertions.assertThat(headerString)
+      .as("headers should NOT have header2")
+      .doesNotContain("header2");
   }
   
   @Test
   public void testTracedServerWithIncludedHeader() {
-    Key<String> headerKey = Metadata.Key.of("user-agent", Metadata.ASCII_STRING_MARSHALLER);
     TracingServerInterceptor tracingInterceptor =
         TracingServerInterceptor.newBuilder()
             .withTracer(serverTracer)
             .withTracedAttributes(TracingServerInterceptor.ServerRequestAttribute.HEADERS)
-            .withIncludedHeaders(headerKey)
+            .withIncludedHeaders(Metadata.Key.of("header2", Metadata.ASCII_STRING_MARSHALLER))
             .build();
     TracedService.addGeeterService(grpcServer.getServiceRegistry(), tracingInterceptor);
+    
+    Map<String, String> headers = new HashMap<>();
+    headers.put("header1", "value1");
+    headers.put("header2", "value2");
 
-    assertEquals("call should complete successfully", "Hello world", client.greet().getMessage());
+    assertEquals("call should complete successfully", "Hello world", client.greetWithHeaders(headers).getMessage());
     await().atMost(5, TimeUnit.SECONDS).until(reportedSpansSize(serverTracer), equalTo(1));
     assertEquals(
         "one span should have been created and finished for one client request",
@@ -330,12 +340,15 @@ public class TracingServerInterceptorTest {
     assertEquals("span should have no parents", span.parentId(), 0);
     assertEquals("span should have no logs", span.logEntries().size(), 0);
     Assertions.assertThat(span.tags())
-        .as("span should have base server tags")
-        .containsKey(GrpcTags.GRPC_HEADERS.getKey());
-    String headers = (String) span.tags().get(GrpcTags.GRPC_HEADERS.getKey());
-    Assertions.assertThat(headers)
-        .as("headers should have user agent")
-        .contains("user-agent");
+      .as("span should have base server tags")
+      .containsKey(GrpcTags.GRPC_HEADERS.getKey());
+    String headerString = (String) span.tags().get(GrpcTags.GRPC_HEADERS.getKey());
+    Assertions.assertThat(headerString)
+      .as("headers should NOT have header1")
+      .doesNotContain("header1");
+    Assertions.assertThat(headerString)
+      .as("headers should have header2")
+      .contains("header2");
   }
 
   @Test


### PR DESCRIPTION
Sometimes headers can contain sensitive information (for example, the **Authorization** header). This update enables the user to optionally specify a list of headers to:

- specifically exclude or
- specifically include