### PR TITLE
Update GRPC Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 
-    <grpc.version>1.27.1</grpc.version>
-    <protobuf.version>3.11.0</protobuf.version>
+    <grpc.version>1.51.1</grpc.version>
+    <protobuf.version>3.21.12</protobuf.version>
     <opentracing.version>0.33.0</opentracing.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
@@ -132,28 +132,28 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>3.13.2</version>
+      <version>3.23.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
-      <version>3.1.6</version>
+      <version>4.2.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.0.0</version>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This PR updates `GRPC` dependencies to ensure this opentracing contrib interops with newer versions of GRPC. This PR also updates `junit`, `assertj`, `mockito`, and `awaitility`.

@malafeev, @ravirajj 

Supersedes #60 with a newer version of GRPC,